### PR TITLE
feat: implement core API endpoints for cities and countries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,10 @@ go.work.sum
 
 # env file
 .env
+
+# IDE
+.idea
+.vscode
+
+.code_examples/
+.envrc

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"net/http"
+)
+
+func (app *application) GetCities(w http.ResponseWriter, r *http.Request) {
+	cities, err := app.models.Cities.GetCityList()
+
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	env := envelope{
+		"status": "available",
+		"system_info": map[string]string{
+			"environment": app.config.env,
+			"version":     version,
+		},
+		"cities": cities,
+	}
+
+	err = app.writeJSON(w, http.StatusOK, env, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"errors"
 	"net/http"
+
+	"github.com/denis-k2/relohelper-go/internal/data"
 )
 
 func (app *application) GetCities(w http.ResponseWriter, r *http.Request) {
@@ -20,6 +23,32 @@ func (app *application) GetCities(w http.ResponseWriter, r *http.Request) {
 		},
 		"cities": cities,
 	}
+
+	err = app.writeJSON(w, http.StatusOK, env, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *application) GetCity(w http.ResponseWriter, r *http.Request) {
+	id, err := app.readIDParam(r)
+	if err != nil {
+		app.notFoundResponse(w, r)
+		return
+	}
+
+	city, err := app.models.Cities.GetCityID(id)
+	if err != nil {
+		switch {
+		case errors.Is(err, data.ErrRecordNotFound):
+			app.notFoundResponse(w, r)
+		default:
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	env := envelope{"city": city}
 
 	err = app.writeJSON(w, http.StatusOK, env, nil)
 	if err != nil {

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -5,24 +5,29 @@ import (
 	"net/http"
 
 	"github.com/denis-k2/relohelper-go/internal/data"
+	"github.com/denis-k2/relohelper-go/internal/validator"
 )
 
 func (app *application) GetCities(w http.ResponseWriter, r *http.Request) {
-	cities, err := app.models.Cities.GetCityList()
+	var input data.Filters
+	v := validator.New()
+	qs := r.URL.Query()
 
+	if len(qs) > 0 {
+		input.CountryCode = app.readString(qs, "country_code", "")
+		if data.ValidateFilters(v, input); !v.Valid() {
+			app.failedValidationResponse(w, r, v.Errors)
+			return
+		}
+	}
+
+	cities, err := app.models.Cities.GetCityList(input.CountryCode)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 		return
 	}
 
-	env := envelope{
-		"status": "available",
-		"system_info": map[string]string{
-			"environment": app.config.env,
-			"version":     version,
-		},
-		"cities": cities,
-	}
+	env := envelope{"cities": cities}
 
 	err = app.writeJSON(w, http.StatusOK, env, nil)
 	if err != nil {

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -91,8 +91,12 @@ func (app *application) GetCity(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if climateEnabled {
-		// TODO: Implement handling for the 'avg_climate' query parameter
-		app.logger.Warn("Handling 'avg_climate' query parameter is incomplete.")
+		avgClimate, err := app.models.Cities.GetAvgClimatePivot(id)
+		if err != nil {
+			app.serverErrorResponse(w, r, err)
+			return
+		}
+		city.AvgClimate = *avgClimate
 	}
 
 	env := envelope{"city": city}

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -82,8 +82,12 @@ func (app *application) GetCity(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if indicesEnabled {
-		// TODO: Implement handling for the 'numbeo_indices' query parameter
-		app.logger.Warn("Handling 'numbeo_indices' query parameter is incomplete.")
+		numbeoIndicies, err := app.models.Cities.GetNumbeoIndicies(id)
+		if err != nil {
+			app.serverErrorResponse(w, r, err)
+			return
+		}
+		city.NumbeoIndices = *numbeoIndicies
 	}
 
 	if climateEnabled {

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -36,6 +36,25 @@ func (app *application) GetCities(w http.ResponseWriter, r *http.Request) {
 }
 
 func (app *application) GetCity(w http.ResponseWriter, r *http.Request) {
+	var input struct {
+		numbeoCost    string
+		numbeoIndices string
+		avgClimate    string
+	}
+	v := validator.New()
+	qs := r.URL.Query()
+
+	input.numbeoCost = app.readString(qs, "numbeo_cost", "")
+	input.numbeoIndices = app.readString(qs, "numbeo_indices", "")
+	input.avgClimate = app.readString(qs, "avg_climate", "")
+	costEnabled := data.ValidateBoolQuery(v, input.numbeoCost)
+	indicesEnabled := data.ValidateBoolQuery(v, input.numbeoIndices)
+	climateEnabled := data.ValidateBoolQuery(v, input.avgClimate)
+	if !v.Valid() {
+		app.failedValidationResponse(w, r, v.Errors)
+		return
+	}
+
 	id, err := app.readIDParam(r)
 	if err != nil {
 		app.notFoundResponse(w, r)
@@ -51,6 +70,25 @@ func (app *application) GetCity(w http.ResponseWriter, r *http.Request) {
 			app.serverErrorResponse(w, r, err)
 		}
 		return
+	}
+
+	if costEnabled {
+		numbeoCost, err := app.models.Cities.GetNumbeoCost(id)
+		if err != nil {
+			app.serverErrorResponse(w, r, err)
+			return
+		}
+		city.NumbeoCost = *numbeoCost
+	}
+
+	if indicesEnabled {
+		// TODO: Implement handling for the 'numbeo_indices' query parameter
+		app.logger.Warn("Handling 'numbeo_indices' query parameter is incomplete.")
+	}
+
+	if climateEnabled {
+		// TODO: Implement handling for the 'avg_climate' query parameter
+		app.logger.Warn("Handling 'avg_climate' query parameter is incomplete.")
 	}
 
 	env := envelope{"city": city}

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -8,7 +8,7 @@ import (
 	"github.com/denis-k2/relohelper-go/internal/validator"
 )
 
-func (app *application) GetCities(w http.ResponseWriter, r *http.Request) {
+func (app *application) listCitiesHandler(w http.ResponseWriter, r *http.Request) {
 	var input data.Filters
 	v := validator.New()
 	qs := r.URL.Query()
@@ -40,7 +40,7 @@ func (app *application) GetCities(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (app *application) GetCity(w http.ResponseWriter, r *http.Request) {
+func (app *application) showCityHandler(w http.ResponseWriter, r *http.Request) {
 	id, err := app.readIDParam(r)
 	if err != nil {
 		app.notFoundResponse(w, r)

--- a/cmd/api/countries.go
+++ b/cmd/api/countries.go
@@ -10,7 +10,7 @@ import (
 	"github.com/denis-k2/relohelper-go/internal/validator"
 )
 
-func (app *application) showCountriesHandler(w http.ResponseWriter, r *http.Request) {
+func (app *application) listCountriesHandler(w http.ResponseWriter, r *http.Request) {
 	countries, err := app.models.Countries.GetCountryList()
 	if err != nil {
 		app.serverErrorResponse(w, r, err)

--- a/cmd/api/countries.go
+++ b/cmd/api/countries.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"net/http"
+)
+
+func (app *application) showCountriesHandler(w http.ResponseWriter, r *http.Request) {
+	countries, err := app.models.Countries.GetCountryList()
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+		return
+	}
+
+	env := envelope{"countries": countries}
+
+	err = app.writeJSON(w, http.StatusOK, env, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}

--- a/cmd/api/countries.go
+++ b/cmd/api/countries.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"errors"
 	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+
+	"github.com/denis-k2/relohelper-go/internal/data"
+	"github.com/denis-k2/relohelper-go/internal/validator"
 )
 
 func (app *application) showCountriesHandler(w http.ResponseWriter, r *http.Request) {
@@ -12,6 +18,34 @@ func (app *application) showCountriesHandler(w http.ResponseWriter, r *http.Requ
 	}
 
 	env := envelope{"countries": countries}
+
+	err = app.writeJSON(w, http.StatusOK, env, nil)
+	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *application) showCountryHandler(w http.ResponseWriter, r *http.Request) {
+	var input data.Filters
+	v := validator.New()
+	input.CountryCode = httprouter.ParamsFromContext(r.Context()).ByName("alpha3")
+	if data.ValidateFilters(v, input); !v.Valid() {
+		app.failedValidationResponse(w, r, v.Errors)
+		return
+	}
+
+	country, err := app.models.Countries.GetCountry(input.CountryCode)
+	if err != nil {
+		switch {
+		case errors.Is(err, data.ErrRecordNotFound):
+			app.notFoundResponse(w, r)
+		default:
+			app.serverErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	env := envelope{"country": country}
 
 	err = app.writeJSON(w, http.StatusOK, env, nil)
 	if err != nil {

--- a/cmd/api/countries.go
+++ b/cmd/api/countries.go
@@ -56,17 +56,29 @@ func (app *application) showCountryHandler(w http.ResponseWriter, r *http.Reques
 	}
 
 	if numbeoIndicesEnabled {
-		numbeoIndicies, err := app.models.Countries.GetNumbeoCountryIndicies(input.CountryCode)
-		if err != nil {
+		numbeoIndices, err := app.models.Countries.GetNumbeoCountryIndicies(input.CountryCode)
+		switch {
+		case err == nil:
+			country.NumbeoIndices = numbeoIndices
+		case errors.Is(err, data.ErrRecordNotFound):
+			country.NumbeoIndices = nil
+		default:
 			app.serverErrorResponse(w, r, err)
 			return
 		}
-		country.NumbeoIndices = *numbeoIndicies
 	}
 
 	if legatumIndicesEnabled {
-		// TODO: Implement handling for the 'numbeo_indices' query parameter
-		app.logger.Warn("Handling 'legatum_indices' query parameter is incomplete.")
+		legatumIndices, err := app.models.Countries.GetLegatumIndicies(input.CountryCode)
+		switch {
+		case err == nil:
+			country.LegatumIndices = legatumIndices
+		case errors.Is(err, data.ErrRecordNotFound):
+			country.LegatumIndices = nil
+		default:
+			app.serverErrorResponse(w, r, err)
+			return
+		}
 	}
 
 	env := envelope{"country": country}

--- a/cmd/api/errors.go
+++ b/cmd/api/errors.go
@@ -34,3 +34,7 @@ func (app *application) notFoundResponse(w http.ResponseWriter, r *http.Request)
 	message := "the requested resource could not be found"
 	app.errorResponse(w, r, http.StatusNotFound, message)
 }
+
+func (app *application) failedValidationResponse(w http.ResponseWriter, r *http.Request, errors map[string]string) {
+	app.errorResponse(w, r, http.StatusUnprocessableEntity, errors)
+}

--- a/cmd/api/errors.go
+++ b/cmd/api/errors.go
@@ -29,3 +29,8 @@ func (app *application) serverErrorResponse(w http.ResponseWriter, r *http.Reque
 	message := "the server encountered a problem and could not process your request"
 	app.errorResponse(w, r, http.StatusInternalServerError, message)
 }
+
+func (app *application) notFoundResponse(w http.ResponseWriter, r *http.Request) {
+	message := "the requested resource could not be found"
+	app.errorResponse(w, r, http.StatusNotFound, message)
+}

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/julienschmidt/httprouter"
+	"maps"
 )
 
 type envelope map[string]any
@@ -28,11 +30,8 @@ func (app *application) writeJSON(w http.ResponseWriter, status int, data envelo
 		return err
 	}
 	js = append(js, '\n')
-
-	for key, value := range headers {
-		w.Header()[key] = value
-	}
-
+	
+	maps.Copy(w.Header(), headers)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if _, err := w.Write(js); err != nil {
@@ -44,4 +43,13 @@ func (app *application) writeJSON(w http.ResponseWriter, status int, data envelo
 
 func ptrString(s string) *string {
 	return &s
+}
+
+func (app *application) readString(qs url.Values, key string, defaultValue string) string {
+	s := qs.Get(key)
+	if s == "" {
+		return defaultValue
+	}
+
+	return s
 }

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -2,10 +2,25 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
+	"strconv"
+
+	"github.com/julienschmidt/httprouter"
 )
 
 type envelope map[string]any
+
+func (app *application) readIDParam(r *http.Request) (int64, error) {
+	params := httprouter.ParamsFromContext(r.Context())
+
+	id, err := strconv.ParseInt(params.ByName("id"), 10, 64)
+	if err != nil || id < 1 {
+		return 0, errors.New("invalid id parameter")
+	}
+
+	return id, nil
+}
 
 func (app *application) writeJSON(w http.ResponseWriter, status int, data envelope, headers http.Header) error {
 	js, err := json.MarshalIndent(data, "", "\t")

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -3,12 +3,12 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"maps"
 	"net/http"
 	"net/url"
 	"strconv"
 
 	"github.com/julienschmidt/httprouter"
-	"maps"
 )
 
 type envelope map[string]any
@@ -30,7 +30,7 @@ func (app *application) writeJSON(w http.ResponseWriter, status int, data envelo
 		return err
 	}
 	js = append(js, '\n')
-	
+
 	maps.Copy(w.Header(), headers)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -2,26 +2,8 @@ package main
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
 	"net/http"
-	"strconv"
-	"strings"
-
-	"github.com/julienschmidt/httprouter"
 )
-
-func (app *application) readIDParam(r *http.Request) (int64, error) {
-	params := httprouter.ParamsFromContext(r.Context())
-
-	id, err := strconv.ParseInt(params.ByName("id"), 10, 64)
-	if err != nil || id < 1 {
-		return 0, errors.New("invalid id parameter")
-	}
-
-	return id, nil
-}
 
 type envelope map[string]any
 
@@ -30,9 +12,6 @@ func (app *application) writeJSON(w http.ResponseWriter, status int, data envelo
 	if err != nil {
 		return err
 	}
-	//fmt.Println(js)          why display 2 byte slises (messege & error)?
-	//fmt.Println(string(js))
-
 	js = append(js, '\n')
 
 	for key, value := range headers {
@@ -41,60 +20,13 @@ func (app *application) writeJSON(w http.ResponseWriter, status int, data envelo
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	w.Write(js)
+	if _, err := w.Write(js); err != nil {
+		return err
+	}
 
 	return nil
 }
 
-func (app *application) readJSON(w http.ResponseWriter, r *http.Request, dst any) error {
-	maxBytes := 1_048_576
-	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))
-
-	dec := json.NewDecoder(r.Body)
-	dec.DisallowUnknownFields()
-
-	err := dec.Decode(dst)
-	if err != nil {
-		var syntaxError *json.SyntaxError
-		var unmarshalTypeError *json.UnmarshalTypeError
-		var invalidUnmarshalError *json.InvalidUnmarshalError
-		var maxBytesError *http.MaxBytesError
-
-		switch {
-		case errors.As(err, &syntaxError):
-			return fmt.Errorf("body contains badly-formed JSON (at character %d)", syntaxError.Offset)
-
-		case errors.Is(err, io.ErrUnexpectedEOF):
-			return errors.New("body contains badly-formed JSON")
-
-		case errors.As(err, &unmarshalTypeError):
-			if unmarshalTypeError.Field != "" {
-				return fmt.Errorf("body contains incorrect JSON type for field %q", unmarshalTypeError.Field)
-			}
-			return fmt.Errorf("body contains incorrect JSON type (at character %d)", unmarshalTypeError.Offset)
-
-		case errors.Is(err, io.EOF):
-			return errors.New("body must not be empty")
-
-		case strings.HasPrefix(err.Error(), "json: unknown field "):
-			fieldName := strings.TrimPrefix(err.Error(), "json: unknown field ")
-			return fmt.Errorf("body contains unknown key %s", fieldName)
-
-		case errors.As(err, &maxBytesError):
-			return fmt.Errorf("body must not be larger than %d bytes", maxBytesError.Limit)
-
-		case errors.As(err, &invalidUnmarshalError):
-			panic(err)
-
-		default:
-			return err
-		}
-	}
-
-	err = dec.Decode(&struct{}{})
-	if !errors.Is(err, io.EOF) {
-		return errors.New("body must only contain a single JSON value")
-	}
-
-	return nil
+func ptrString(s string) *string {
+	return &s
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,14 +1,18 @@
 package main
 
 import (
-	// "context"
-	// "expvar"
+	"context"
+	"database/sql"
 	"flag"
 	"fmt"
-	"github.com/denis-k2/relohelper-go/internal/vcs"
 	"log/slog"
 	"os"
-	"sync"
+	"time"
+
+	_ "github.com/lib/pq"
+
+	"github.com/denis-k2/relohelper-go/internal/data"
+	"github.com/denis-k2/relohelper-go/internal/vcs"
 )
 
 var (
@@ -19,37 +23,90 @@ var (
 type config struct {
 	port int
 	env  string
+	db   struct {
+		dsn          string
+		maxOpenConns int
+		maxIdleConns int
+		maxIdleTime  time.Duration
+	}
 }
 
 type application struct {
 	config config
 	logger *slog.Logger
-	wg     sync.WaitGroup
+	models data.Models
 }
 
 func main() {
+	cfg, err := parseFlags()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	db, err := openDB(cfg)
+	if err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
+	defer db.Close()
+	logger.Info("database connection pool established")
+
+	app := &application{
+		config: cfg,
+		logger: logger,
+		models: data.NewModels(db),
+	}
+
+	err = app.serve()
+	if err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
+}
+
+func parseFlags() (config, error) {
 	var cfg config
 
 	flag.IntVar(&cfg.port, "port", 4000, "API server port")
-	flag.StringVar(&cfg.env, "env", "development", "Environment (development|staging|production)")
+	flag.StringVar(&cfg.env, "env", "development", "Environment (development|staging|production|testLogs)")
+
+	flag.StringVar(&cfg.db.dsn, "db-dsn", os.Getenv("RELOHELPER_DB_DSN"), "PostgreSQL DSN")
+	flag.IntVar(&cfg.db.maxOpenConns, "db-max-open-conns", 25, "PostgreSQL max open connections")
+	flag.IntVar(&cfg.db.maxIdleConns, "db-max-idle-conns", 25, "PostgreSQL max idle connections")
+	flag.DurationVar(&cfg.db.maxIdleTime, "db-max-idle-time", 15*time.Minute, "PostgreSQL max connection idle time")
 
 	displayVersion := flag.Bool("version", false, "Display version and exit")
+
 	flag.Parse()
+
 	if *displayVersion {
 		fmt.Printf("Version:\t%s\n", version)
 		os.Exit(0)
 	}
 
-	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	return cfg, nil
+}
 
-	app := &application{
-		config: cfg,
-		logger: logger,
-	}
-
-	err := app.serve()
+func openDB(cfg config) (*sql.DB, error) {
+	db, err := sql.Open("postgres", cfg.db.dsn)
 	if err != nil {
-		logger.Error(err.Error())
-		os.Exit(1)
+		return nil, err
 	}
+
+	db.SetMaxOpenConns(cfg.db.maxOpenConns)
+	db.SetMaxIdleConns(cfg.db.maxIdleConns)
+	db.SetConnMaxIdleTime(cfg.db.maxIdleTime)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err = db.PingContext(ctx)
+	if err != nil {
+		db.Close()
+		return nil, err
+	}
+
+	return db, nil
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -14,6 +14,7 @@ func (app *application) routes() http.Handler {
 	router.HandlerFunc(http.MethodGet, "/cities", app.GetCities)
 	router.HandlerFunc(http.MethodGet, "/cities/:id", app.GetCity)
 	router.HandlerFunc(http.MethodGet, "/countries", app.showCountriesHandler)
+	router.HandlerFunc(http.MethodGet, "/countries/:alpha3", app.showCountryHandler)
 
 	return router
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -12,6 +12,7 @@ func (app *application) routes() http.Handler {
 	router.HandlerFunc(http.MethodGet, "/healthcheck", app.healthcheckHandler)
 
 	router.HandlerFunc(http.MethodGet, "/cities", app.GetCities)
+	router.HandlerFunc(http.MethodGet, "/cities/:id", app.GetCity)
 
 	return router
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -11,9 +11,9 @@ func (app *application) routes() http.Handler {
 
 	router.HandlerFunc(http.MethodGet, "/healthcheck", app.healthcheckHandler)
 
-	router.HandlerFunc(http.MethodGet, "/cities", app.GetCities)
-	router.HandlerFunc(http.MethodGet, "/cities/:id", app.GetCity)
-	router.HandlerFunc(http.MethodGet, "/countries", app.showCountriesHandler)
+	router.HandlerFunc(http.MethodGet, "/cities", app.listCitiesHandler)
+	router.HandlerFunc(http.MethodGet, "/cities/:id", app.showCityHandler)
+	router.HandlerFunc(http.MethodGet, "/countries", app.listCountriesHandler)
 	router.HandlerFunc(http.MethodGet, "/countries/:alpha3", app.showCountryHandler)
 
 	return router

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -13,6 +13,7 @@ func (app *application) routes() http.Handler {
 
 	router.HandlerFunc(http.MethodGet, "/cities", app.GetCities)
 	router.HandlerFunc(http.MethodGet, "/cities/:id", app.GetCity)
+	router.HandlerFunc(http.MethodGet, "/countries", app.showCountriesHandler)
 
 	return router
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -9,7 +9,9 @@ import (
 func (app *application) routes() http.Handler {
 	router := httprouter.New()
 
-	router.HandlerFunc(http.MethodGet, "/v1/healthcheck", app.healthcheckHandler)
+	router.HandlerFunc(http.MethodGet, "/healthcheck", app.healthcheckHandler)
+
+	router.HandlerFunc(http.MethodGet, "/cities", app.GetCities)
 
 	return router
 }

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -529,7 +529,7 @@ func TestCountryandQuery(t *testing.T) {
 		queryParams QueryParamsCountry
 	}{
 		{
-			name:     "One param enabled",
+			name:     "Enable only Numbeo indices",
 			urlPath:  "/countries/rus?numbeo_indices=true",
 			wantCode: http.StatusOK,
 			queryParams: QueryParamsCountry{
@@ -537,26 +537,44 @@ func TestCountryandQuery(t *testing.T) {
 				legatumIndicesEnabled: false,
 			},
 		},
-		// {
-		// 	name:     "Another one param enabled",
-		// 	urlPath:  "/countries/usa?legatum_indices=TRUE",
-		// 	wantCode: http.StatusOK,
-		// 	queryParams: QueryParamsCountry{
-		// 		numbeoIndicesEnabled:  false,
-		// 		legatumIndicesEnabled: true,
-		// 	},
-		// },
-		// {
-		// 	name:     "All params enabled",
-		// 	urlPath:  "/countries/rus?numbeo_indices=1&legatum_indices=True",
-		// 	wantCode: http.StatusOK,
-		// 	queryParams: QueryParamsCountry{
-		// 		numbeoIndicesEnabled:  true,
-		// 		legatumIndicesEnabled: true,
-		// 	},
-		// },
 		{
-			name:     "One param with false value",
+			name:     "Enable only Legatum indices",
+			urlPath:  "/countries/usa?legatum_indices=TRUE",
+			wantCode: http.StatusOK,
+			queryParams: QueryParamsCountry{
+				numbeoIndicesEnabled:  false,
+				legatumIndicesEnabled: true,
+			},
+		},
+		{
+			name:     "Enable all params (Numbeo and Legatum)",
+			urlPath:  "/countries/bra?numbeo_indices=1&legatum_indices=True",
+			wantCode: http.StatusOK,
+			queryParams: QueryParamsCountry{
+				numbeoIndicesEnabled:  true,
+				legatumIndicesEnabled: true,
+			},
+		},
+		{
+			name:     "Enable both params with missing Numbeo data",
+			urlPath:  "/countries/afg?numbeo_indices=t&legatum_indices=true",
+			wantCode: http.StatusOK,
+			queryParams: QueryParamsCountry{
+				numbeoIndicesEnabled:  false,
+				legatumIndicesEnabled: true,
+			},
+		},
+		{
+			name:     "Enable both params with missing both data",
+			urlPath:  "/countries/wlf?numbeo_indices=t&legatum_indices=t",
+			wantCode: http.StatusOK,
+			queryParams: QueryParamsCountry{
+				numbeoIndicesEnabled:  false,
+				legatumIndicesEnabled: false,
+			},
+		},
+		{
+			name:     "Disable only Numbeo indices",
 			urlPath:  "/countries/can?numbeo_indices=0",
 			wantCode: http.StatusOK,
 			queryParams: QueryParamsCountry{
@@ -579,7 +597,7 @@ func TestCountryandQuery(t *testing.T) {
 			wantCode: http.StatusOK,
 			queryParams: QueryParamsCountry{
 				numbeoIndicesEnabled:  false,
-				legatumIndicesEnabled: false,
+				legatumIndicesEnabled: true,
 			},
 		},
 		{

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -33,13 +33,7 @@ func TestCities(t *testing.T) {
 	assert.Equal(t, statusCode, http.StatusOK)
 	assert.Equal(t, header.Get("content-type"), "application/json")
 
-	type citiesResponse struct {
-		Status      string      `json:"status"`
-		Cities      []data.City `json:"cities"`
-		CountryCode string      `json:"country_code"`
-	}
-
-	var got citiesResponse
+	var got gotResponse
 	unmarshalJSON(t, body, &got)
 	assert.Equal(t, len(got.Cities), 534)
 
@@ -139,18 +133,13 @@ func TestCitiesByCountry(t *testing.T) {
 		},
 	}
 
-	type citiesResponse struct {
-		Cities []data.City `json:"cities"`
-		Error  any         `json:"error"`
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			url := fmt.Sprintf("/cities?country_code=%s", tt.countryCode)
 			statusCode, header, body := ts.get(t, url)
 			assert.Equal(t, statusCode, tt.expectedCode)
 
-			var got citiesResponse
+			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 			assert.Equal(t, len(got.Cities), tt.expectedCnt)
@@ -230,19 +219,13 @@ func TestCityID(t *testing.T) {
 		},
 	}
 
-	type cityResponse struct {
-		City  data.City `json:"city"`
-		Error any       `json:"error"`
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, header, body := ts.get(t, tt.urlPath)
-
 			assert.Equal(t, statusCode, tt.wantCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
-			var got cityResponse
+			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.DeepEqual(t, got.City, tt.wantBody)
 
@@ -346,19 +329,13 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 	}
 
-	type cityResponse struct {
-		City  data.City `json:"city"`
-		Error any       `json:"error"`
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, header, body := ts.get(t, tt.urlPath)
-
 			assert.Equal(t, statusCode, tt.wantCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
-			var got cityResponse
+			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.DeepEqual(t, cityFildsToBool(got.City), tt.queryParams)
 
@@ -381,11 +358,7 @@ func TestCountries(t *testing.T) {
 	assert.Equal(t, statusCode, http.StatusOK)
 	assert.Equal(t, header.Get("content-type"), "application/json")
 
-	type countriesResponse struct {
-		Countries []data.Country `json:"countries"`
-	}
-
-	var got countriesResponse
+	var got gotResponse
 	unmarshalJSON(t, body, &got)
 	assert.Equal(t, len(got.Countries), 249)
 
@@ -503,20 +476,14 @@ func TestCountry(t *testing.T) {
 		},
 	}
 
-	type countriesResponse struct {
-		Country data.Country `json:"country"`
-		Error   any          `json:"error"`
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, header, body := ts.get(t, tt.urlPath)
 			assert.Equal(t, statusCode, tt.expectedCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
-			var got countriesResponse
+			var got gotResponse
 			unmarshalJSON(t, body, &got)
-
 			assert.DeepEqual(t, got.Country, tt.country)
 
 			switch tt.expectedCode {
@@ -627,19 +594,13 @@ func TestCountryandQuery(t *testing.T) {
 		},
 	}
 
-	type countriesResponse struct {
-		Country data.Country `json:"country"`
-		Error   any          `json:"error"`
-	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, header, body := ts.get(t, tt.urlPath)
-
 			assert.Equal(t, statusCode, tt.wantCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
-			var got countriesResponse
+			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.DeepEqual(t, countryFildsToBool(got.Country), tt.queryParams)
 

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -356,3 +356,54 @@ func TestCityIDandQuery(t *testing.T) {
 		})
 	}
 }
+
+// TestCountries tests the “/countries" endpoint.
+func TestCountries(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, body := ts.get(t, "/countries")
+	assert.Equal(t, statusCode, http.StatusOK)
+	assert.Equal(t, header.Get("content-type"), "application/json")
+
+	type countriesResponse struct {
+		Countries []data.Country `json:"countries"`
+	}
+
+	var got countriesResponse
+	unmarshalJSON(t, body, &got)
+	assert.Equal(t, len(got.Countries), 249)
+
+	tests := []struct {
+		index   int
+		country data.Country
+	}{
+		{
+			index: 14,
+			country: data.Country{
+				Code: "AUS",
+				Name: "Australia",
+			},
+		},
+		{
+			index: 111,
+			country: data.Country{
+				Code: "ITA",
+				Name: "Italy",
+			},
+		},
+		{
+			index: 218,
+			country: data.Country{
+				Code: "THA",
+				Name: "Thailand",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Check country code=%s", tt.country.Code), func(t *testing.T) {
+			assert.DeepEqual(t, got.Countries[tt.index], tt.country)
+		})
+	}
+}

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/denis-k2/relohelper-go/internal/assert"
+	"github.com/denis-k2/relohelper-go/internal/data"
+)
+
+// TestHealthcheck tests the "/healthcheck" endpoint.
+func TestHealthcheck(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, body := ts.get(t, "/healthcheck")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, header.Get("content-type"), "application/json")
+
+	var got envelope
+	unmarshalJSON(t, body, &got)
+	assert.Equal(t, got["status"], "available")
+}
+
+// TestCities tests the “/cities” endpoint.
+func TestCities(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, body := ts.get(t, "/cities")
+	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, header.Get("content-type"), "application/json")
+
+	type citiesResponse struct {
+		Status string      `json:"status"`
+		Cities []data.City `json:"cities"`
+	}
+
+	var got citiesResponse
+	unmarshalJSON(t, body, &got)
+	assert.Equal(t, got.Status, "available")
+	assert.Equal(t, 534, len(got.Cities))
+
+	wantCities := []data.City{
+		{
+			CityID:      11,
+			City:        "New York",
+			StateCode:   ptrString("US-NY"),
+			CountryCode: "USA",
+		},
+		{
+			CityID:      94,
+			City:        "Toronto",
+			StateCode:   nil,
+			CountryCode: "CAN",
+		},
+		{
+			CityID:      464,
+			City:        "Moscow",
+			StateCode:   nil,
+			CountryCode: "RUS",
+		},
+	}
+	for _, city := range wantCities {
+		assert.DeepEqual(t, got.Cities[city.CityID-1], city)
+	}
+}

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -255,25 +255,34 @@ func TestCityID(t *testing.T) {
 	}
 }
 
-// TestCities tests the “/cities/:id” endpoint with query parameter.
+// TestCities tests the “/cities/:id” endpoint with query parameters.
 func TestCityIDandQuery(t *testing.T) {
 	ts := newTestServer(testApp.routes())
 	defer ts.Close()
 
 	tests := []struct {
-		name     string
-		urlPath  string
-		wantCode int
+		name        string
+		urlPath     string
+		wantCode    int
+		queryParams QueryParams
 	}{
 		{
 			name:     "Valid query string 1",
 			urlPath:  "/cities/12?numbeo_cost=true",
 			wantCode: http.StatusOK,
+			queryParams: QueryParams{
+				costEnabled:    true,
+				indicesEnabled: false,
+			},
 		},
 		{
 			name:     "Valid query string 2",
-			urlPath:  "/cities/123?numbeo_cost=1",
+			urlPath:  "/cities/123?numbeo_cost=1&numbeo_indices=t",
 			wantCode: http.StatusOK,
+			queryParams: QueryParams{
+				costEnabled:    true,
+				indicesEnabled: true,
+			},
 		},
 		{
 			name:     "Unprocessable query value (123)",
@@ -301,8 +310,8 @@ func TestCityIDandQuery(t *testing.T) {
 				var got cityResponse
 				unmarshalJSON(t, body, &got)
 				assert.Equal(t, got.City.NumbeoCost.Currency, "USD")
-				assert.Equal(t, len(got.City.NumbeoCost.LastUpdate), 10)
 				assert.Equal(t, len(got.City.NumbeoCost.Prices), 57)
+				assert.DeepEqual(t, cityFildsToBool(got.City), tt.queryParams)
 			}
 		})
 	}

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -68,68 +68,68 @@ func TestCitiesByCountry(t *testing.T) {
 	defer ts.Close()
 
 	tests := []struct {
-		name         string
-		countryCode  string
-		expectedCnt  int
-		expectedCode int
+		name        string
+		countryCode string
+		citiesCount int
+		statusCode  int
 	}{
 		{
-			name:         "Valid uppercase code (USA)",
-			countryCode:  "USA",
-			expectedCnt:  58,
-			expectedCode: http.StatusOK,
+			name:        "Valid uppercase code (USA)",
+			countryCode: "USA",
+			citiesCount: 58,
+			statusCode:  http.StatusOK,
 		},
 		{
-			name:         "Valid mixed case code (cAn)",
-			countryCode:  "cAn",
-			expectedCnt:  29,
-			expectedCode: http.StatusOK,
+			name:        "Valid mixed case code (cAn)",
+			countryCode: "cAn",
+			citiesCount: 29,
+			statusCode:  http.StatusOK,
 		},
 		{
-			name:         "Valid lowercase code (rus)",
-			countryCode:  "rus",
-			expectedCnt:  8,
-			expectedCode: http.StatusOK,
+			name:        "Valid lowercase code (rus)",
+			countryCode: "rus",
+			citiesCount: 8,
+			statusCode:  http.StatusOK,
 		},
 		{
-			name:         "Nonexistent country code (XXX)",
-			countryCode:  "xxx",
-			expectedCode: http.StatusNotFound,
+			name:        "Nonexistent country code (XXX)",
+			countryCode: "xxx",
+			statusCode:  http.StatusNotFound,
 		},
 		{
-			name:         "Non-alphabetic code (123)",
-			countryCode:  "123",
-			expectedCode: http.StatusUnprocessableEntity,
+			name:        "Non-alphabetic code (123)",
+			countryCode: "123",
+			statusCode:  http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Empty country code",
-			countryCode:  "",
-			expectedCode: http.StatusUnprocessableEntity,
+			name:        "Empty country code",
+			countryCode: "",
+			statusCode:  http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Code with 1 letter (a)",
-			countryCode:  "a",
-			expectedCode: http.StatusUnprocessableEntity,
+			name:        "Code with 1 letter (a)",
+			countryCode: "a",
+			statusCode:  http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Code with 4 letters (usaa)",
-			countryCode:  "usaa",
-			expectedCode: http.StatusUnprocessableEntity,
+			name:        "Code with 4 letters (usaa)",
+			countryCode: "usaa",
+			statusCode:  http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Code with whitespace",
-			countryCode:  url.QueryEscape(" us "),
-			expectedCode: http.StatusUnprocessableEntity,
+			name:        "Code with whitespace",
+			countryCode: url.QueryEscape(" us "),
+			statusCode:  http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Code with special characters (#$%)",
-			countryCode:  url.QueryEscape("#$%"),
-			expectedCode: http.StatusUnprocessableEntity,
+			name:        "Code with special characters (#$%)",
+			countryCode: url.QueryEscape("#$%"),
+			statusCode:  http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "SQL injection attempt",
-			countryCode:  url.QueryEscape("usa'; DROP TABLE cities;--"),
-			expectedCode: http.StatusUnprocessableEntity,
+			name:        "SQL injection attempt",
+			countryCode: url.QueryEscape("usa'; DROP TABLE city;"),
+			statusCode:  http.StatusUnprocessableEntity,
 		},
 	}
 
@@ -137,19 +137,19 @@ func TestCitiesByCountry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			url := fmt.Sprintf("/cities?country_code=%s", tt.countryCode)
 			statusCode, header, body := ts.get(t, url)
-			assert.Equal(t, statusCode, tt.expectedCode)
+			assert.Equal(t, statusCode, tt.statusCode)
 
 			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.Equal(t, header.Get("content-type"), "application/json")
-			assert.Equal(t, len(got.Cities), tt.expectedCnt)
+			assert.Equal(t, len(got.Cities), tt.citiesCount)
 
-			switch tt.expectedCode {
+			switch tt.statusCode {
 			case http.StatusUnprocessableEntity:
-				expectedError := map[string]any{
+				wantError := map[string]any{
 					"country_code": "must be exactly three English letters",
 				}
-				assert.DeepEqual(t, got.Error, expectedError)
+				assert.DeepEqual(t, got.Error, wantError)
 			case http.StatusNotFound:
 				assert.Equal(t, got.Error, "the requested resource could not be found")
 			}
@@ -163,16 +163,16 @@ func TestCityID(t *testing.T) {
 	defer ts.Close()
 
 	tests := []struct {
-		name     string
-		urlPath  string
-		wantCode int
-		wantBody data.City
+		name       string
+		urlPath    string
+		statusCode int
+		city       data.City
 	}{
 		{
-			name:     "Valid ID (No query params)",
-			urlPath:  "/cities/15",
-			wantCode: http.StatusOK,
-			wantBody: data.City{
+			name:       "Valid ID (No query params)",
+			urlPath:    "/cities/15",
+			statusCode: http.StatusOK,
+			city: data.City{
 				CityID:      15,
 				City:        "Seattle",
 				StateCode:   ptrString("US-WA"),
@@ -181,10 +181,10 @@ func TestCityID(t *testing.T) {
 			},
 		},
 		{
-			name:     "Valid ID with False & extra query params",
-			urlPath:  "/cities/273?numbeo_cost=false&numbeo_indices=0&avg_climate=&extra_param=true",
-			wantCode: http.StatusOK,
-			wantBody: data.City{
+			name:       "Valid ID with False & extra query params",
+			urlPath:    "/cities/273?numbeo_cost=false&numbeo_indices=0&avg_climate=&extra_param=true",
+			statusCode: http.StatusOK,
+			city: data.City{
 				CityID:      273,
 				City:        "Tokyo",
 				StateCode:   nil,
@@ -193,43 +193,43 @@ func TestCityID(t *testing.T) {
 			},
 		},
 		{
-			name:     "Non-existent ID",
-			urlPath:  "/cities/777",
-			wantCode: http.StatusNotFound,
+			name:       "Non-existent ID",
+			urlPath:    "/cities/777",
+			statusCode: http.StatusNotFound,
 		},
 		{
-			name:     "Negative ID",
-			urlPath:  "/cities/-1",
-			wantCode: http.StatusNotFound,
+			name:       "Negative ID",
+			urlPath:    "/cities/-1",
+			statusCode: http.StatusNotFound,
 		},
 		{
-			name:     "Decimal ID",
-			urlPath:  "/cities/1.23",
-			wantCode: http.StatusNotFound,
+			name:       "Decimal ID",
+			urlPath:    "/cities/1.23",
+			statusCode: http.StatusNotFound,
 		},
 		{
-			name:     "String ID",
-			urlPath:  "/cities/foo",
-			wantCode: http.StatusNotFound,
+			name:       "String ID",
+			urlPath:    "/cities/foo",
+			statusCode: http.StatusNotFound,
 		},
 		{
-			name:     "Empty ID",
-			urlPath:  "/cities/",
-			wantCode: http.StatusOK,
+			name:       "Empty ID",
+			urlPath:    "/cities/",
+			statusCode: http.StatusOK,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, header, body := ts.get(t, tt.urlPath)
-			assert.Equal(t, statusCode, tt.wantCode)
+			assert.Equal(t, statusCode, tt.statusCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
 			var got gotResponse
 			unmarshalJSON(t, body, &got)
-			assert.DeepEqual(t, got.City, tt.wantBody)
+			assert.DeepEqual(t, got.City, tt.city)
 
-			if tt.wantCode == http.StatusNotFound {
+			if tt.statusCode == http.StatusNotFound {
 				assert.Equal(t, got.Error, "the requested resource could not be found")
 			}
 		})
@@ -244,106 +244,106 @@ func TestCityIDandQuery(t *testing.T) {
 	tests := []struct {
 		name        string
 		urlPath     string
-		wantCode    int
-		queryParams QueryParams
+		statusCode  int
+		queryParams queryParamsCity
 	}{
 		{
-			name:     "One param enabled",
-			urlPath:  "/cities/12?numbeo_cost=true",
-			wantCode: http.StatusOK,
-			queryParams: QueryParams{
+			name:       "One param enabled",
+			urlPath:    "/cities/12?numbeo_cost=true",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCity{
 				costEnabled:    true,
 				indicesEnabled: false,
 				climateEnabled: false,
 			},
 		},
 		{
-			name:     "Two params enabled",
-			urlPath:  "/cities/123?numbeo_cost=1&numbeo_indices=TRUE&avg_climate=f",
-			wantCode: http.StatusOK,
-			queryParams: QueryParams{
+			name:       "Two params enabled",
+			urlPath:    "/cities/123?numbeo_cost=1&numbeo_indices=TRUE&avg_climate=f",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCity{
 				costEnabled:    true,
 				indicesEnabled: true,
 				climateEnabled: false,
 			},
 		},
 		{
-			name:     "All params enabled",
-			urlPath:  "/cities/456?numbeo_cost=t&numbeo_indices=1&avg_climate=True",
-			wantCode: http.StatusOK,
-			queryParams: QueryParams{
+			name:       "All params enabled",
+			urlPath:    "/cities/456?numbeo_cost=t&numbeo_indices=1&avg_climate=True",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCity{
 				costEnabled:    true,
 				indicesEnabled: true,
 				climateEnabled: true,
 			},
 		},
 		{
-			name:     "Enable both params with missing Avg Climate data",
-			urlPath:  "/cities/329?numbeo_cost=t&numbeo_indices=1&avg_climate=t",
-			wantCode: http.StatusOK,
-			queryParams: QueryParams{
+			name:       "Enable both params with missing Avg Climate data",
+			urlPath:    "/cities/329?numbeo_cost=t&numbeo_indices=1&avg_climate=t",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCity{
 				costEnabled:    true,
 				indicesEnabled: true,
 				climateEnabled: false,
 			},
 		},
 		{
-			name:     "One param with false value",
-			urlPath:  "/cities/321?numbeo_indices=0",
-			wantCode: http.StatusOK,
-			queryParams: QueryParams{
+			name:       "One param with false value",
+			urlPath:    "/cities/321?numbeo_indices=0",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCity{
 				costEnabled:    false,
 				indicesEnabled: false,
 				climateEnabled: false,
 			},
 		},
 		{
-			name:     "Unknown params (mixed cases)",
-			urlPath:  "/cities/123?NUMBEO_COST=1&Numbeo_Indices=true&InvalidParam=TRUE",
-			wantCode: http.StatusOK,
-			queryParams: QueryParams{
+			name:       "Unknown params (mixed cases)",
+			urlPath:    "/cities/123?NUMBEO_COST=1&Numbeo_Indices=true&InvalidParam=TRUE",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCity{
 				costEnabled:    false, // Upper case parameter not recognized
 				indicesEnabled: false, // CamelCase parameter not recognized
 				climateEnabled: false,
 			},
 		},
 		{
-			name:     "Duplicate params",
-			urlPath:  "/cities/234?numbeo_cost=false&numbeo_cost=true&avg_climate=1",
-			wantCode: http.StatusOK,
-			queryParams: QueryParams{
+			name:       "Duplicate params",
+			urlPath:    "/cities/234?numbeo_cost=false&numbeo_cost=true&avg_climate=1",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCity{
 				costEnabled:    false,
 				indicesEnabled: false,
 				climateEnabled: true,
 			},
 		},
 		{
-			name:     "Unprocessable query value (123)",
-			urlPath:  "/cities/100?numbeo_cost=123",
-			wantCode: http.StatusUnprocessableEntity,
+			name:       "Unprocessable query value (123)",
+			urlPath:    "/cities/100?numbeo_cost=123",
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:     "Unprocessable query value (abc)",
-			urlPath:  "/cities/100?numbeo_cost=abc",
-			wantCode: http.StatusUnprocessableEntity,
+			name:       "Unprocessable query value (abc)",
+			urlPath:    "/cities/100?numbeo_cost=abc",
+			statusCode: http.StatusUnprocessableEntity,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, header, body := ts.get(t, tt.urlPath)
-			assert.Equal(t, statusCode, tt.wantCode)
+			assert.Equal(t, statusCode, tt.statusCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
 			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.DeepEqual(t, cityFildsToBool(got.City), tt.queryParams)
 
-			if tt.wantCode == http.StatusUnprocessableEntity {
-				expectedError := map[string]any{
+			if tt.statusCode == http.StatusUnprocessableEntity {
+				wantError := map[string]any{
 					"query parameter": "must be a boolean value",
 				}
-				assert.DeepEqual(t, got.Error, expectedError)
+				assert.DeepEqual(t, got.Error, wantError)
 			}
 		})
 	}
@@ -402,96 +402,96 @@ func TestCountry(t *testing.T) {
 	defer ts.Close()
 
 	tests := []struct {
-		name         string
-		urlPath      string
-		expectedCode int
-		country      data.Country
+		name       string
+		urlPath    string
+		statusCode int
+		country    data.Country
 	}{
 		{
-			name:         "Valid uppercase code (AUS)",
-			urlPath:      "/countries/AUS",
-			expectedCode: http.StatusOK,
+			name:       "Valid uppercase code (AUS)",
+			urlPath:    "/countries/AUS",
+			statusCode: http.StatusOK,
 			country: data.Country{
 				Code: "AUS",
 				Name: "Australia",
 			},
 		},
 		{
-			name:         "Valid mixed case code (iTa)",
-			urlPath:      "/countries/iTa",
-			expectedCode: http.StatusOK,
+			name:       "Valid mixed case code (iTa)",
+			urlPath:    "/countries/iTa",
+			statusCode: http.StatusOK,
 			country: data.Country{
 				Code: "ITA",
 				Name: "Italy",
 			},
 		},
 		{
-			name:         "Valid lowercase code (tha)",
-			urlPath:      "/countries/tha",
-			expectedCode: http.StatusOK,
+			name:       "Valid lowercase code (tha)",
+			urlPath:    "/countries/tha",
+			statusCode: http.StatusOK,
 			country: data.Country{
 				Code: "THA",
 				Name: "Thailand",
 			},
 		},
 		{
-			name:         "Nonexistent country code (XXX)",
-			urlPath:      "/countries/XXX",
-			expectedCode: http.StatusNotFound,
+			name:       "Nonexistent country code (XXX)",
+			urlPath:    "/countries/XXX",
+			statusCode: http.StatusNotFound,
 		},
 		{
-			name:         "Non-alphabetic code (123)",
-			urlPath:      "/countries/123",
-			expectedCode: http.StatusUnprocessableEntity,
+			name:       "Non-alphabetic code (123)",
+			urlPath:    "/countries/123",
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Empty country code",
-			urlPath:      "/countries/",
-			expectedCode: http.StatusOK,
+			name:       "Empty country code",
+			urlPath:    "/countries/",
+			statusCode: http.StatusOK,
 		},
 		{
-			name:         "Code with 1 letter (a)",
-			urlPath:      "/countries/a",
-			expectedCode: http.StatusUnprocessableEntity,
+			name:       "Code with 1 letter (a)",
+			urlPath:    "/countries/a",
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Code with 4 letters (usaa)",
-			urlPath:      "/countries/usaa",
-			expectedCode: http.StatusUnprocessableEntity,
+			name:       "Code with 4 letters (usaa)",
+			urlPath:    "/countries/usaa",
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Code with whitespace",
-			urlPath:      "/countries/ us ",
-			expectedCode: http.StatusUnprocessableEntity,
+			name:       "Code with whitespace",
+			urlPath:    "/countries/ us ",
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "Code with special characters (#$%)",
-			urlPath:      "/countries/" + url.QueryEscape("#$%"),
-			expectedCode: http.StatusUnprocessableEntity,
+			name:       "Code with special characters (#$%)",
+			urlPath:    "/countries/" + url.QueryEscape("#$%"),
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:         "SQL injection attempt",
-			urlPath:      "/countries/" + url.QueryEscape("usa'; DROP TABLE cities;--"),
-			expectedCode: http.StatusUnprocessableEntity,
+			name:       "SQL injection attempt",
+			urlPath:    "/countries/" + url.QueryEscape("usa'; DROP TABLE country;"),
+			statusCode: http.StatusUnprocessableEntity,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, header, body := ts.get(t, tt.urlPath)
-			assert.Equal(t, statusCode, tt.expectedCode)
+			assert.Equal(t, statusCode, tt.statusCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
 			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.DeepEqual(t, got.Country, tt.country)
 
-			switch tt.expectedCode {
+			switch tt.statusCode {
 			case http.StatusUnprocessableEntity:
-				expectedError := map[string]any{
+				wantError := map[string]any{
 					"country_code": "must be exactly three English letters",
 				}
-				assert.DeepEqual(t, got.Error, expectedError)
+				assert.DeepEqual(t, got.Error, wantError)
 			case http.StatusNotFound:
 				assert.Equal(t, got.Error, "the requested resource could not be found")
 			}
@@ -507,108 +507,108 @@ func TestCountryandQuery(t *testing.T) {
 	tests := []struct {
 		name        string
 		urlPath     string
-		wantCode    int
-		queryParams QueryParamsCountry
+		statusCode  int
+		queryParams queryParamsCountry
 	}{
 		{
-			name:     "Enable only Numbeo indices",
-			urlPath:  "/countries/rus?numbeo_indices=true",
-			wantCode: http.StatusOK,
-			queryParams: QueryParamsCountry{
+			name:       "Enable only Numbeo indices",
+			urlPath:    "/countries/rus?numbeo_indices=true",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  true,
 				legatumIndicesEnabled: false,
 			},
 		},
 		{
-			name:     "Enable only Legatum indices",
-			urlPath:  "/countries/usa?legatum_indices=TRUE",
-			wantCode: http.StatusOK,
-			queryParams: QueryParamsCountry{
+			name:       "Enable only Legatum indices",
+			urlPath:    "/countries/usa?legatum_indices=TRUE",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
 				legatumIndicesEnabled: true,
 			},
 		},
 		{
-			name:     "Enable all params (Numbeo and Legatum)",
-			urlPath:  "/countries/bra?numbeo_indices=1&legatum_indices=True",
-			wantCode: http.StatusOK,
-			queryParams: QueryParamsCountry{
+			name:       "Enable all params (Numbeo and Legatum)",
+			urlPath:    "/countries/bra?numbeo_indices=1&legatum_indices=True",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  true,
 				legatumIndicesEnabled: true,
 			},
 		},
 		{
-			name:     "Enable both params with missing Numbeo data",
-			urlPath:  "/countries/afg?numbeo_indices=t&legatum_indices=true",
-			wantCode: http.StatusOK,
-			queryParams: QueryParamsCountry{
+			name:       "Enable both params with missing Numbeo data",
+			urlPath:    "/countries/afg?numbeo_indices=t&legatum_indices=true",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
 				legatumIndicesEnabled: true,
 			},
 		},
 		{
-			name:     "Enable both params with missing both data",
-			urlPath:  "/countries/wlf?numbeo_indices=t&legatum_indices=t",
-			wantCode: http.StatusOK,
-			queryParams: QueryParamsCountry{
+			name:       "Enable both params with missing both data",
+			urlPath:    "/countries/wlf?numbeo_indices=t&legatum_indices=t",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
 				legatumIndicesEnabled: false,
 			},
 		},
 		{
-			name:     "Disable only Numbeo indices",
-			urlPath:  "/countries/can?numbeo_indices=0",
-			wantCode: http.StatusOK,
-			queryParams: QueryParamsCountry{
+			name:       "Disable only Numbeo indices",
+			urlPath:    "/countries/can?numbeo_indices=0",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
 				legatumIndicesEnabled: false,
 			},
 		},
 		{
-			name:     "Unknown params (mixed cases)",
-			urlPath:  "/countries/arg?Numbeo_Indices=true&LEGATHUM_INDICES=1&InvalidParam=TRUE",
-			wantCode: http.StatusOK,
-			queryParams: QueryParamsCountry{
+			name:       "Unknown params (mixed cases)",
+			urlPath:    "/countries/arg?Numbeo_Indices=true&LEGATHUM_INDICES=1&InvalidParam=TRUE",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false, // CamelCase parameter not recognized
 				legatumIndicesEnabled: false, // Upper case parameter not recognized
 			},
 		},
 		{
-			name:     "Duplicate params",
-			urlPath:  "/countries/chn?numbeo_indices=false&numbeo_indices=true&legatum_indices=1",
-			wantCode: http.StatusOK,
-			queryParams: QueryParamsCountry{
+			name:       "Duplicate params",
+			urlPath:    "/countries/chn?numbeo_indices=false&numbeo_indices=true&legatum_indices=1",
+			statusCode: http.StatusOK,
+			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
 				legatumIndicesEnabled: true,
 			},
 		},
 		{
-			name:     "Unprocessable query value (123)",
-			urlPath:  "/countries/deu?numbeo_indices=123",
-			wantCode: http.StatusUnprocessableEntity,
+			name:       "Unprocessable query value (123)",
+			urlPath:    "/countries/deu?numbeo_indices=123",
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:     "Unprocessable query value (abc)",
-			urlPath:  "/countries/nld?numbeo_indices=abc",
-			wantCode: http.StatusUnprocessableEntity,
+			name:       "Unprocessable query value (abc)",
+			urlPath:    "/countries/nld?numbeo_indices=abc",
+			statusCode: http.StatusUnprocessableEntity,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			statusCode, header, body := ts.get(t, tt.urlPath)
-			assert.Equal(t, statusCode, tt.wantCode)
+			assert.Equal(t, statusCode, tt.statusCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
 			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.DeepEqual(t, countryFildsToBool(got.Country), tt.queryParams)
 
-			if tt.wantCode == http.StatusUnprocessableEntity {
-				expectedError := map[string]any{
+			if tt.statusCode == http.StatusUnprocessableEntity {
+				wantError := map[string]any{
 					"query parameter": "must be a boolean value",
 				}
-				assert.DeepEqual(t, got.Error, expectedError)
+				assert.DeepEqual(t, got.Error, wantError)
 			}
 		})
 	}

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -28,7 +28,7 @@ func TestCities(t *testing.T) {
 	defer ts.Close()
 
 	statusCode, header, body := ts.get(t, "/cities")
-	assert.Equal(t, http.StatusOK, statusCode)
+	assert.Equal(t, statusCode, http.StatusOK)
 	assert.Equal(t, header.Get("content-type"), "application/json")
 
 	type citiesResponse struct {
@@ -63,5 +63,84 @@ func TestCities(t *testing.T) {
 	}
 	for _, city := range wantCities {
 		assert.DeepEqual(t, got.Cities[city.CityID-1], city)
+	}
+}
+
+// TestCity tests the “/cities/:id” endpoint.
+func TestCityID(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	tests := []struct {
+		name     string
+		urlPath  string
+		wantCode int
+		wantBody data.City
+	}{
+		{
+			name:     "Valid ID 1",
+			urlPath:  "/cities/15",
+			wantCode: http.StatusOK,
+			wantBody: data.City{
+				CityID:      15,
+				City:        "Seattle",
+				StateCode:   ptrString("US-WA"),
+				CountryCode: "USA",
+			},
+		},
+		{
+			name:     "Valid ID 2",
+			urlPath:  "/cities/273",
+			wantCode: http.StatusOK,
+			wantBody: data.City{
+				CityID:      273,
+				City:        "Tokyo",
+				StateCode:   nil,
+				CountryCode: "JPN",
+			},
+		},
+		{
+			name:     "Non-existent ID",
+			urlPath:  "/cities/777",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "Negative ID",
+			urlPath:  "/cities/-1",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "Decimal ID",
+			urlPath:  "/cities/1.23",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "String ID",
+			urlPath:  "/cities/foo",
+			wantCode: http.StatusNotFound,
+		},
+		{
+			name:     "Empty ID",
+			urlPath:  "/cities/",
+			wantCode: http.StatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusCode, header, body := ts.get(t, tt.urlPath)
+
+			assert.Equal(t, statusCode, tt.wantCode)
+			assert.Equal(t, header.Get("content-type"), "application/json")
+
+			if tt.wantBody != (data.City{}) {
+				type cityResponse struct {
+					City data.City `json:"city"`
+				}
+				var got cityResponse
+				unmarshalJSON(t, body, &got)
+				assert.DeepEqual(t, got.City, tt.wantBody)
+			}
+		})
 	}
 }

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -34,15 +34,7 @@ func (app *application) serve() error {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		err := srv.Shutdown(ctx)
-		if err != nil {
-			shutdownError <- err
-		}
-
-		app.logger.Info("completing background tasks", "addr", srv.Addr)
-
-		app.wg.Wait()
-		shutdownError <- nil
+		shutdownError <- srv.Shutdown(ctx)
 	}()
 
 	app.logger.Info("starting server", "addr", srv.Addr, "env", app.config.env)

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/denis-k2/relohelper-go/internal/data"
+)
+
+var (
+	logger  *slog.Logger
+	testApp *application
+	testDB  *sql.DB
+)
+
+// configureTestLogger configures a logger for testing.
+// Logs are printed to os.Stdout at Debug level when env flag is "testLogs",
+// otherwise output is discarded.
+func configureTestLogger(env string) {
+	if env == "testLogs" {
+		// Verbose logger for debugging: output to os.Stdout.
+		logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}))
+	} else {
+		// Silent logger to keep test output clean
+		logger = slog.New(slog.DiscardHandler)
+	}
+}
+
+func TestMain(m *testing.M) {
+	testCfg, err := parseFlags()
+	if err != nil {
+		logger.Error("failed to parse flags", "error", err)
+		os.Exit(1)
+	}
+
+	configureTestLogger(testCfg.env)
+
+	testApp, testDB, err = newTestApplication(testCfg)
+	if err != nil {
+		logger.Error("failed to initialize application", "error", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := testDB.Close(); err != nil {
+		logger.Error("failed to close DB", "error", err)
+	}
+
+	os.Exit(code)
+}
+
+func newTestApplication(cfg config) (*application, *sql.DB, error) {
+	db, err := openDB(cfg)
+	if err != nil {
+		logger.Error("database connection error", "error", err)
+		return nil, nil, err
+	}
+	logger.Info("database connection pool established")
+
+	return &application{
+		config: cfg,
+		logger: logger,
+		models: data.NewModels(db),
+	}, db, nil
+}
+
+type testServer struct {
+	*httptest.Server
+}
+
+func newTestServer(h http.Handler) *testServer {
+	ts := httptest.NewTLSServer(h)
+	return &testServer{ts}
+}
+
+func (ts *testServer) get(t *testing.T, urlPath string) (int, http.Header, []byte) {
+	rs, err := ts.Client().Get(ts.URL + urlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer rs.Body.Close()
+	body, err := io.ReadAll(rs.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = bytes.TrimSpace(body)
+
+	return rs.StatusCode, rs.Header, body
+}
+
+func unmarshalJSON(t *testing.T, body []byte, gotPtr any) {
+	err := json.Unmarshal(body, gotPtr)
+	if err != nil {
+		t.Fatalf("Unable to parse %q: %v", body, err)
+	}
+}

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -106,6 +106,14 @@ func unmarshalJSON(t *testing.T, body []byte, gotPtr any) {
 	}
 }
 
+type gotResponse struct {
+	City    data.City    `json:"city"`
+	Cities  []data.City  `json:"cities"`
+	Country data.Country `json:"country"`
+	Countries []data.Country `json:"countries"`
+	Error   any          `json:"error"`
+}
+
 type QueryParams struct {
 	costEnabled    bool
 	indicesEnabled bool

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -109,11 +109,13 @@ func unmarshalJSON(t *testing.T, body []byte, gotPtr any) {
 type QueryParams struct {
 	costEnabled    bool
 	indicesEnabled bool
+	climateEnabled bool
 }
 
 func cityFildsToBool(c data.City) QueryParams {
 	return QueryParams{
-		costEnabled:    len(c.NumbeoCost.LastUpdate) == 10,
+		costEnabled:    len(c.NumbeoCost.LastUpdate) == 10 && len(c.NumbeoCost.Prices) == 57,
 		indicesEnabled: len(c.NumbeoIndices.LastUpdate) == 10,
+		climateEnabled: c.AvgClimate.Measures != nil,
 	}
 }

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -127,8 +127,7 @@ type QueryParamsCountry struct {
 
 func countryFildsToBool(c data.Country) QueryParamsCountry {
 	return QueryParamsCountry{
-		numbeoIndicesEnabled: len(c.NumbeoIndices.LastUpdate) == 10,
-		// TODO: Implement legatum indices handling once the data source is available.
-		legatumIndicesEnabled: false,
+		numbeoIndicesEnabled:  c.NumbeoIndices != nil,
+		legatumIndicesEnabled: c.LegatumIndices != nil,
 	}
 }

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -119,3 +119,16 @@ func cityFildsToBool(c data.City) QueryParams {
 		climateEnabled: c.AvgClimate.Measures != nil,
 	}
 }
+
+type QueryParamsCountry struct {
+	numbeoIndicesEnabled  bool
+	legatumIndicesEnabled bool
+}
+
+func countryFildsToBool(c data.Country) QueryParamsCountry {
+	return QueryParamsCountry{
+		numbeoIndicesEnabled: len(c.NumbeoIndices.LastUpdate) == 10,
+		// TODO: Implement legatum indices handling once the data source is available.
+		legatumIndicesEnabled: false,
+	}
+}

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -107,34 +107,34 @@ func unmarshalJSON(t *testing.T, body []byte, gotPtr any) {
 }
 
 type gotResponse struct {
-	City    data.City    `json:"city"`
-	Cities  []data.City  `json:"cities"`
-	Country data.Country `json:"country"`
+	City      data.City      `json:"city"`
+	Cities    []data.City    `json:"cities"`
+	Country   data.Country   `json:"country"`
 	Countries []data.Country `json:"countries"`
-	Error   any          `json:"error"`
+	Error     any            `json:"error"`
 }
 
-type QueryParams struct {
+type queryParamsCity struct {
 	costEnabled    bool
 	indicesEnabled bool
 	climateEnabled bool
 }
 
-func cityFildsToBool(c data.City) QueryParams {
-	return QueryParams{
+func cityFildsToBool(c data.City) queryParamsCity {
+	return queryParamsCity{
 		costEnabled:    c.NumbeoCost != nil,
 		indicesEnabled: c.NumbeoIndices != nil,
 		climateEnabled: c.AvgClimate != nil,
 	}
 }
 
-type QueryParamsCountry struct {
+type queryParamsCountry struct {
 	numbeoIndicesEnabled  bool
 	legatumIndicesEnabled bool
 }
 
-func countryFildsToBool(c data.Country) QueryParamsCountry {
-	return QueryParamsCountry{
+func countryFildsToBool(c data.Country) queryParamsCountry {
+	return queryParamsCountry{
 		numbeoIndicesEnabled:  c.NumbeoIndices != nil,
 		legatumIndicesEnabled: c.LegatumIndices != nil,
 	}

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -105,3 +105,15 @@ func unmarshalJSON(t *testing.T, body []byte, gotPtr any) {
 		t.Fatalf("Unable to parse %q: %v", body, err)
 	}
 }
+
+type QueryParams struct {
+	costEnabled    bool
+	indicesEnabled bool
+}
+
+func cityFildsToBool(c data.City) QueryParams {
+	return QueryParams{
+		costEnabled:    len(c.NumbeoCost.LastUpdate) == 10,
+		indicesEnabled: len(c.NumbeoIndices.LastUpdate) == 10,
+	}
+}

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -114,9 +114,9 @@ type QueryParams struct {
 
 func cityFildsToBool(c data.City) QueryParams {
 	return QueryParams{
-		costEnabled:    len(c.NumbeoCost.LastUpdate) == 10 && len(c.NumbeoCost.Prices) == 57,
-		indicesEnabled: len(c.NumbeoIndices.LastUpdate) == 10,
-		climateEnabled: c.AvgClimate.Measures != nil,
+		costEnabled:    c.NumbeoCost != nil,
+		indicesEnabled: c.NumbeoIndices != nil,
+		climateEnabled: c.AvgClimate != nil,
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/denis-k2/relohelper-go
 
-go 1.23.4
+go 1.24.0
 
 require github.com/julienschmidt/httprouter v1.3.0
+
+require github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=

--- a/internal/assert/assert.go
+++ b/internal/assert/assert.go
@@ -1,0 +1,38 @@
+package assert
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Equal[T comparable](t *testing.T, actual, expected T) {
+	t.Helper()
+
+	if actual != expected {
+		t.Errorf("got: %v; want: %v", actual, expected)
+	}
+}
+
+func DeepEqual(t *testing.T, actual, expected any) {
+	t.Helper()
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Errorf("got: %v; want: %v", actual, expected)
+	}
+}
+
+func StringContains(t *testing.T, actual, expectedSubstring string) {
+	t.Helper()
+
+	if !strings.Contains(actual, expectedSubstring) {
+		t.Errorf("got: %q; expected to contain: %q", actual, expectedSubstring)
+	}
+}
+func NilError(t *testing.T, actual error) {
+	t.Helper()
+
+	if actual != nil {
+		t.Errorf("got: %v; expected: nil", actual)
+	}
+}

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -1,0 +1,59 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+type City struct {
+	CityID      int64   `json:"city_id"`
+	City        string  `json:"city"`
+	StateCode   *string `json:"state_code"`
+	CountryCode string  `json:"country_code"`
+}
+
+type CityModel struct {
+	DB *sql.DB
+}
+
+func (c CityModel) GetCityList() ([]*City, error) {
+	query := `
+        SELECT city_id, city, state_code, country_code
+		FROM city
+		ORDER BY city_id;`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	rows, err := c.DB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	cities := []*City{}
+
+	for rows.Next() {
+		var city City
+
+		err := rows.Scan(
+			&city.CityID,
+			&city.City,
+			&city.StateCode,
+			&city.CountryCode,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		cities = append(cities, &city)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return cities, nil
+}

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -18,16 +18,17 @@ type CityModel struct {
 	DB *sql.DB
 }
 
-func (c CityModel) GetCityList() ([]*City, error) {
+func (c CityModel) GetCityList(countryСode string) ([]*City, error) {
 	query := `
         SELECT city_id, city, state_code, country_code
 		FROM city
+		WHERE (LOWER(country_code) = LOWER($1) OR $1 = '')
 		ORDER BY city_id;`
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	rows, err := c.DB.QueryContext(ctx, query)
+	rows, err := c.DB.QueryContext(ctx, query, countryСode)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -8,14 +8,14 @@ import (
 )
 
 type City struct {
-	CityID        int64       `json:"city_id"`
-	City          string      `json:"city"`
-	StateCode     *string     `json:"state_code"`
-	CountryCode   string      `json:"country_code"`
-	Country       string      `json:"country,omitzero"`
-	NumbeoCost    CostDetails `json:"numbeo_cost,omitzero"`
-	NumbeoIndices Indices     `json:"numbeo_indices,omitzero"`
-	AvgClimate    AvgClimate  `json:"avg_climate,omitzero"`
+	CityID        int64        `json:"city_id"`
+	City          string       `json:"city"`
+	StateCode     *string      `json:"state_code"`
+	CountryCode   string       `json:"country_code"`
+	Country       string       `json:"country,omitzero"`
+	NumbeoCost    *CostDetails `json:"numbeo_cost,omitzero"`
+	NumbeoIndices *Indices     `json:"numbeo_indices,omitzero"`
+	AvgClimate    *AvgClimate  `json:"avg_climate,omitzero"`
 }
 
 type CostDetails struct {
@@ -124,7 +124,9 @@ func (c CityModel) GetCityList(countryСode string) ([]*City, error) {
 
 	cities := []*City{}
 
+	dataFound := false
 	for rows.Next() {
+		dataFound = true
 		var city City
 
 		err := rows.Scan(
@@ -143,6 +145,10 @@ func (c CityModel) GetCityList(countryСode string) ([]*City, error) {
 
 	if err = rows.Err(); err != nil {
 		return nil, err
+	}
+
+	if !dataFound {
+		return nil, ErrRecordNotFound
 	}
 
 	return cities, nil

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -196,6 +197,42 @@ func TestGetNumbeoCost(t *testing.T) {
 			assert.Equal(t, cost.Currency, tt.currency)
 			assert.Equal(t, len(cost.LastUpdate), tt.dateLength)
 			assert.Equal(t, len(cost.Prices), tt.priceItems)
+		})
+	}
+}
+
+func TestGetNumbeoIndicies(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	tests := []struct {
+		name       string
+		cityID     int64
+		itemsCount int
+		dateLength int
+		valueFloat float64
+		valueNil   *float64
+	}{
+		{"exist", 100, 13, 10, 71.7, nil},
+		{"exist", 200, 13, 10, 64.8, nil},
+		{"exist", 300, 13, 10, 51.8, nil},
+		{"exist", 400, 13, 10, 39.1, nil},
+		{"exist", 500, 13, 10, 28.9, nil},
+		{"not exist", 600, 0, 0, 0, nil},
+		{"not exist", -700, 0, 0, 0, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Get Numbeo Indicies by City id=%d (%s)", tt.cityID, tt.name), func(t *testing.T) {
+			index, err := models.Cities.GetNumbeoIndicies(tt.cityID)
+			if err != nil {
+				assert.Equal(t, err, ErrRecordNotFound)
+				return
+			}
+			assert.Equal(t, len(index.LastUpdate), tt.dateLength)
+			assert.Equal(t, reflect.TypeOf(Indices{}).NumField(), tt.itemsCount)
+			assert.Equal(t, *index.CostOfLiving, tt.valueFloat)
+			assert.Equal(t, index.QualityOfLife, tt.valueNil)
 		})
 	}
 }

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -97,7 +97,8 @@ func TestGetCityListByCountry(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			cities, err := models.Cities.GetCityList(tt.countryCode)
 			if err != nil {
-				t.Fatal(err)
+				assert.Equal(t, err, ErrRecordNotFound)
+				return
 			}
 			assert.Equal(t, len(cities), tt.expectedCnt)
 

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -230,7 +230,7 @@ func TestGetNumbeoIndicies(t *testing.T) {
 				return
 			}
 			assert.Equal(t, len(index.LastUpdate), tt.dateLength)
-			assert.Equal(t, reflect.TypeOf(Indices{}).NumField(), tt.itemsCount)
+			assert.Equal(t, reflect.TypeOf(*index).NumField(), tt.itemsCount)
 			assert.Equal(t, *index.CostOfLiving, tt.valueFloat)
 			assert.Equal(t, index.QualityOfLife, tt.valueNil)
 		})

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"fmt"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -42,5 +43,42 @@ func TestGetCityList(t *testing.T) {
 	}
 	for _, city := range wantCities {
 		assert.DeepEqual(t, *cities[city.CityID-1], city)
+	}
+}
+
+func TestGetCityID(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	stateMA := "US-MA"
+	wantCity := []City{
+		{
+			CityID:      19,
+			City:        "Boston",
+			StateCode:   &stateMA,
+			CountryCode: "USA",
+		},
+		{
+			CityID:      319,
+			City:        "Valencia",
+			StateCode:   nil,
+			CountryCode: "ESP",
+		},
+		{
+			CityID:      487,
+			City:        "Kaliningrad",
+			StateCode:   nil,
+			CountryCode: "RUS",
+		},
+	}
+
+	for _, want := range wantCity {
+		t.Run(fmt.Sprintf("Get City id=%d", want.CityID), func(t *testing.T) {
+			city, err := models.Cities.GetCityID(want.CityID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assert.DeepEqual(t, *city, want)
+		})
 	}
 }

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -236,3 +236,36 @@ func TestGetNumbeoIndicies(t *testing.T) {
 		})
 	}
 }
+
+func TestGetAvgClimatePivot(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	humidityJanuaryOf11 := 74.0
+	humidityJanuaryOf444 := 78.0
+	tests := []struct {
+		name            string
+		cityID          int64
+		itemsCount      int
+		humidityJanuary *float64 // random value for testing
+	}{
+		{"exist", 11, 17, &humidityJanuaryOf11},
+		{"exist", 111, 17, nil},
+		{"exist", 333, 17, nil},
+		{"exist", 444, 17, &humidityJanuaryOf444},
+		{"not exist", 555, 0, nil},
+		{"not exist", -777, 0, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Get Average Climate by City id=%d (%s)", tt.cityID, tt.name), func(t *testing.T) {
+			climate, err := models.Cities.GetAvgClimatePivot(tt.cityID)
+			if err != nil {
+				assert.Equal(t, err, ErrRecordNotFound)
+				return
+			}
+			assert.Equal(t, reflect.TypeOf(AvgClimate{}).NumField(), tt.itemsCount)
+			assert.DeepEqual(t, climate.Humidity.January, tt.humidityJanuary)
+		})
+	}
+}

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -1,0 +1,46 @@
+package data
+
+import (
+	"testing"
+
+	_ "github.com/lib/pq"
+
+	"github.com/denis-k2/relohelper-go/internal/assert"
+)
+
+func TestGetCityList(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	cities, err := models.Cities.GetCityList()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, 534, len(cities))
+
+	stateOH := "US-OH"
+	wantCities := []City{
+		{
+			CityID:      1,
+			City:        "Hamilton",
+			StateCode:   nil,
+			CountryCode: "BMU",
+		},
+		{
+			CityID:      235,
+			City:        "Cincinnati",
+			StateCode:   &stateOH,
+			CountryCode: "USA",
+		},
+		{
+			CityID:      534,
+			City:        "Karachi",
+			StateCode:   nil,
+			CountryCode: "PAK",
+		},
+	}
+	for _, city := range wantCities {
+		assert.DeepEqual(t, *cities[city.CityID-1], city)
+	}
+}

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -130,18 +130,27 @@ func TestGetCityID(t *testing.T) {
 			City:        "Boston",
 			StateCode:   &stateMA,
 			CountryCode: "USA",
+			Country:     "United States of America",
 		},
 		{
 			CityID:      319,
 			City:        "Valencia",
 			StateCode:   nil,
 			CountryCode: "ESP",
+			Country:     "Spain",
 		},
 		{
 			CityID:      487,
 			City:        "Kaliningrad",
 			StateCode:   nil,
 			CountryCode: "RUS",
+			Country:     "Russian Federation",
+		},
+		{
+			CityID: 4000,
+		},
+		{
+			CityID: -5000,
 		},
 	}
 
@@ -149,9 +158,44 @@ func TestGetCityID(t *testing.T) {
 		t.Run(fmt.Sprintf("Get City id=%d", want.CityID), func(t *testing.T) {
 			city, err := models.Cities.GetCityID(want.CityID)
 			if err != nil {
-				t.Fatal(err)
+				assert.Equal(t, err, ErrRecordNotFound)
+				return
 			}
 			assert.DeepEqual(t, *city, want)
+		})
+	}
+}
+
+func TestGetNumbeoCost(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	tests := []struct {
+		name       string
+		cityID     int64
+		currency   string
+		dateLength int
+		priceItems int
+	}{
+		{"exist", 100, "USD", 10, 57},
+		{"exist", 200, "USD", 10, 57},
+		{"exist", 300, "USD", 10, 57},
+		{"exist", 400, "USD", 10, 57},
+		{"exist", 500, "USD", 10, 57},
+		{"not exist", 600, "", 0, 0},
+		{"not exist", -700, "", 0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Get Numbeo Cost by City id=%d (%s)", tt.cityID, tt.name), func(t *testing.T) {
+			cost, err := models.Cities.GetNumbeoCost(tt.cityID)
+			if err != nil {
+				assert.Equal(t, err, ErrRecordNotFound)
+				return
+			}
+			assert.Equal(t, cost.Currency, tt.currency)
+			assert.Equal(t, len(cost.LastUpdate), tt.dateLength)
+			assert.Equal(t, len(cost.Prices), tt.priceItems)
 		})
 	}
 }

--- a/internal/data/countries.go
+++ b/internal/data/countries.go
@@ -1,0 +1,55 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+type Country struct {
+	Code string `json:"country_code"`
+	Name string `json:"country"`
+}
+
+type CountryModel struct {
+	DB *sql.DB
+}
+
+func (c CountryModel) GetCountryList() ([]*Country, error) {
+	query := `
+        SELECT country_code, country
+		FROM country
+		ORDER BY country_code;`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	rows, err := c.DB.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	countries := []*Country{}
+
+	for rows.Next() {
+		var country Country
+
+		err := rows.Scan(
+			&country.Code,
+			&country.Name,
+		)
+
+		if err != nil {
+			return nil, err
+		}
+
+		countries = append(countries, &country)
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return countries, nil
+}

--- a/internal/data/countries.go
+++ b/internal/data/countries.go
@@ -8,8 +8,27 @@ import (
 )
 
 type Country struct {
-	Code string `json:"country_code"`
-	Name string `json:"country"`
+	Code          string                `json:"country_code"`
+	Name          string                `json:"country"`
+	NumbeoIndices NumbeoCountryIndicies `json:"numbeo_indices,omitzero"`
+}
+
+type NumbeoCountryIndicies struct {
+	CostOfLiving               *float64 `json:"cost_of_living"`
+	Rent                       *float64 `json:"rent"`
+	CostOfLivingPlusRent       *float64 `json:"cost_of_living_plus_rent"`
+	Groceries                  *float64 `json:"groceries"`
+	RestaurantPrice            *float64 `json:"restaurant_price"`
+	LocalPurchasingPower       *float64 `json:"local_purchasing_power"`
+	QualityOfLife              *float64 `json:"quality_of_life"`
+	PropertyPriceToIncomeRatio *float64 `json:"property_price_to_income_ratio"`
+	TrafficCommuteTime         *float64 `json:"traffic_commute_time"`
+	Climate                    *float64 `json:"climate"`
+	Safety                     *float64 `json:"safety"`
+	HealthCare                 *float64 `json:"health_care"`
+	Pollution                  *float64 `json:"pollution"`
+	AvgSalaryUSD               *float64 `json:"avg_salary_usd"`
+	LastUpdate                 string   `json:"last_update"`
 }
 
 type CountryModel struct {
@@ -59,7 +78,7 @@ func (c CountryModel) GetCountry(countryCode string) (*Country, error) {
 	query := `
 		SELECT country_code, country
 		FROM country
-		WHERE (LOWER(country_code) = LOWER($1));`
+		WHERE LOWER(country_code) = LOWER($1);`
 
 	var country Country
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -80,4 +99,60 @@ func (c CountryModel) GetCountry(countryCode string) (*Country, error) {
 	}
 
 	return &country, nil
+}
+
+func (c CountryModel) GetNumbeoCountryIndicies(country_code string) (*NumbeoCountryIndicies, error) {
+	query := `
+		SELECT
+			cost_of_living,
+			rent,
+			cost_of_living_plus_rent,
+			groceries,
+			restaurant_price,
+			local_purchasing_power,
+			quality_of_life,
+			property_price_to_income_ratio,
+			traffic_commute_time,
+			climate,
+			safety,
+			health_care,
+			pollution,
+			avg_salary_usd,
+			to_char(sys_updated_date, 'YYYY-MM-DD')
+		FROM numbeo_index_by_country
+		WHERE LOWER(country_code) = LOWER($1);`
+
+	var index NumbeoCountryIndicies
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := c.DB.QueryRowContext(ctx, query, country_code).Scan(
+		&index.CostOfLiving,
+		&index.Rent,
+		&index.CostOfLivingPlusRent,
+		&index.Groceries,
+		&index.RestaurantPrice,
+		&index.LocalPurchasingPower,
+		&index.QualityOfLife,
+		&index.PropertyPriceToIncomeRatio,
+		&index.TrafficCommuteTime,
+		&index.Climate,
+		&index.Safety,
+		&index.HealthCare,
+		&index.Pollution,
+		&index.AvgSalaryUSD,
+		&index.LastUpdate,
+	)
+
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return nil, ErrRecordNotFound
+		default:
+			return nil, err
+		}
+	}
+
+	return &index, nil
 }

--- a/internal/data/countries.go
+++ b/internal/data/countries.go
@@ -8,9 +8,10 @@ import (
 )
 
 type Country struct {
-	Code          string                `json:"country_code"`
-	Name          string                `json:"country"`
-	NumbeoIndices NumbeoCountryIndicies `json:"numbeo_indices,omitzero"`
+	Code           string                 `json:"country_code"`
+	Name           string                 `json:"country"`
+	NumbeoIndices  *NumbeoCountryIndicies `json:"numbeo_indices,omitempty"`
+	LegatumIndices *LegatumCountryIndices `json:"legatum_indices,omitempty"`
 }
 
 type NumbeoCountryIndicies struct {
@@ -29,6 +30,58 @@ type NumbeoCountryIndicies struct {
 	Pollution                  *float64 `json:"pollution"`
 	AvgSalaryUSD               *float64 `json:"avg_salary_usd"`
 	LastUpdate                 string   `json:"last_update"`
+}
+
+type LegatumCountryIndices struct {
+	SafetyAndSecurity             RankAndScore `json:"safety_and_security"`
+	PersonalFreedom               RankAndScore `json:"personal_freedom"`
+	Governance                    RankAndScore `json:"governance"`
+	SocialCapital                 RankAndScore `json:"social_capital"`
+	InvestmentEnvironment         RankAndScore `json:"investment_invironment"`
+	EnterpriseConditions          RankAndScore `json:"enterprise_conditions"`
+	InfrastructureAndMarketAccess RankAndScore `json:"infrastructure_and_market_access"`
+	EconomicQuality               RankAndScore `json:"economic_quality"`
+	LivingConditions              RankAndScore `json:"living_conditions"`
+	Health                        RankAndScore `json:"health"`
+	Education                     RankAndScore `json:"education"`
+	NaturalEnvironment            RankAndScore `json:"natural_environment"`
+}
+
+type RankAndScore struct {
+	Rank2007  int     `json:"rank_2007"`
+	Rank2008  int     `json:"rank_2008"`
+	Rank2009  int     `json:"rank_2009"`
+	Rank2010  int     `json:"rank_2010"`
+	Rank2011  int     `json:"rank_2011"`
+	Rank2012  int     `json:"rank_2012"`
+	Rank2013  int     `json:"rank_2013"`
+	Rank2014  int     `json:"rank_2014"`
+	Rank2015  int     `json:"rank_2015"`
+	Rank2016  int     `json:"rank_2016"`
+	Rank2017  int     `json:"rank_2017"`
+	Rank2018  int     `json:"rank_2018"`
+	Rank2019  int     `json:"rank_2019"`
+	Rank2020  int     `json:"rank_2020"`
+	Rank2021  int     `json:"rank_2021"`
+	Rank2022  int     `json:"rank_2022"`
+	Rank2023  int     `json:"rank_2023"`
+	Score2007 float64 `json:"score_2007"`
+	Score2008 float64 `json:"score_2008"`
+	Score2009 float64 `json:"score_2009"`
+	Score2010 float64 `json:"score_2010"`
+	Score2011 float64 `json:"score_2011"`
+	Score2012 float64 `json:"score_2012"`
+	Score2013 float64 `json:"score_2013"`
+	Score2014 float64 `json:"score_2014"`
+	Score2015 float64 `json:"score_2015"`
+	Score2016 float64 `json:"score_2016"`
+	Score2017 float64 `json:"score_2017"`
+	Score2018 float64 `json:"score_2018"`
+	Score2019 float64 `json:"score_2019"`
+	Score2020 float64 `json:"score_2020"`
+	Score2021 float64 `json:"score_2021"`
+	Score2022 float64 `json:"score_2022"`
+	Score2023 float64 `json:"score_2023"`
 }
 
 type CountryModel struct {
@@ -155,4 +208,112 @@ func (c CountryModel) GetNumbeoCountryIndicies(country_code string) (*NumbeoCoun
 	}
 
 	return &index, nil
+}
+
+func (c CountryModel) GetLegatumIndicies(country_code string) (*LegatumCountryIndices, error) {
+	query := `
+	SELECT 
+		pillar_name,
+		rank_2007, rank_2008, rank_2009, rank_2010, rank_2011, rank_2012, rank_2013, rank_2014,
+		rank_2015, rank_2016, rank_2017, rank_2018, rank_2019, rank_2020, rank_2021, rank_2022, rank_2023,
+		score_2007, score_2008, score_2009, score_2010, score_2011, score_2012, score_2013, score_2014,
+		score_2015, score_2016, score_2017, score_2018, score_2019, score_2020, score_2021, score_2022, score_2023
+	FROM legatum_index
+	WHERE LOWER(country_code) = LOWER($1);`
+
+	var legatum LegatumCountryIndices
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	rows, err := c.DB.QueryContext(ctx, query, country_code)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	dataFound := false
+	for rows.Next() {
+		dataFound = true
+		var pillarName string
+		var rankScore RankAndScore
+
+		err := rows.Scan(
+			&pillarName,
+			&rankScore.Rank2007,
+			&rankScore.Rank2008,
+			&rankScore.Rank2009,
+			&rankScore.Rank2010,
+			&rankScore.Rank2011,
+			&rankScore.Rank2012,
+			&rankScore.Rank2013,
+			&rankScore.Rank2014,
+			&rankScore.Rank2015,
+			&rankScore.Rank2016,
+			&rankScore.Rank2017,
+			&rankScore.Rank2018,
+			&rankScore.Rank2019,
+			&rankScore.Rank2020,
+			&rankScore.Rank2021,
+			&rankScore.Rank2022,
+			&rankScore.Rank2023,
+			&rankScore.Score2007,
+			&rankScore.Score2008,
+			&rankScore.Score2009,
+			&rankScore.Score2010,
+			&rankScore.Score2011,
+			&rankScore.Score2012,
+			&rankScore.Score2013,
+			&rankScore.Score2014,
+			&rankScore.Score2015,
+			&rankScore.Score2016,
+			&rankScore.Score2017,
+			&rankScore.Score2018,
+			&rankScore.Score2019,
+			&rankScore.Score2020,
+			&rankScore.Score2021,
+			&rankScore.Score2022,
+			&rankScore.Score2023,
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		switch pillarName {
+		case "Safety and Security":
+			legatum.SafetyAndSecurity = rankScore
+		case "Personal Freedom":
+			legatum.PersonalFreedom = rankScore
+		case "Governance":
+			legatum.Governance = rankScore
+		case "Social Capital":
+			legatum.SocialCapital = rankScore
+		case "Investment Environment":
+			legatum.InvestmentEnvironment = rankScore
+		case "Enterprise Conditions":
+			legatum.EnterpriseConditions = rankScore
+		case "Infrastructure and Market Access":
+			legatum.InfrastructureAndMarketAccess = rankScore
+		case "Economic Quality":
+			legatum.EconomicQuality = rankScore
+		case "Living Conditions":
+			legatum.LivingConditions = rankScore
+		case "Health":
+			legatum.Health = rankScore
+		case "Education":
+			legatum.Education = rankScore
+		case "Natural Environment":
+			legatum.NaturalEnvironment = rankScore
+		}
+	}
+
+	if err = rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if !dataFound {
+		return nil, ErrRecordNotFound
+	}
+
+	return &legatum, nil
 }

--- a/internal/data/countries_test.go
+++ b/internal/data/countries_test.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -112,6 +113,41 @@ func TestGetCountry(t *testing.T) {
 				return
 			}
 			assert.DeepEqual(t, *country, tt.country)
+		})
+	}
+}
+
+func TestGetNumbeoCountryIndicies(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	tests := []struct {
+		name          string
+		country_code  string
+		itemsCount    int
+		dateLength    int
+		avgSalaryUSD  float64  // random float value
+		qualityOfLife *float64 // random nil value
+	}{
+		{"exist", "CRI", 15, 10, 867.19, nil},
+		{"exist", "jam", 15, 10, 663.61, nil},
+		{"exist", "mus", 15, 10, 499.8, nil},
+		{"exist", "Uzb", 15, 10, 340.5, nil},
+		{"not exist", "xxx", 0, 0, 0, nil},
+		{"not exist", "123", 0, 0, 0, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Get Numbeo Indicies by Country code=%s (%s)", tt.country_code, tt.name), func(t *testing.T) {
+			index, err := models.Countries.GetNumbeoCountryIndicies(tt.country_code)
+			if err != nil {
+				assert.Equal(t, err, ErrRecordNotFound)
+				return
+			}
+			assert.Equal(t, len(index.LastUpdate), tt.dateLength)
+			assert.Equal(t, reflect.TypeOf(*index).NumField(), tt.itemsCount)
+			assert.Equal(t, *index.AvgSalaryUSD, tt.avgSalaryUSD)
+			assert.Equal(t, index.QualityOfLife, tt.qualityOfLife)
 		})
 	}
 }

--- a/internal/data/countries_test.go
+++ b/internal/data/countries_test.go
@@ -1,0 +1,54 @@
+package data
+
+import (
+	"fmt"
+	"testing"
+
+	_ "github.com/lib/pq"
+
+	"github.com/denis-k2/relohelper-go/internal/assert"
+)
+
+func TestGetCountryList(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	countries, err := models.Countries.GetCountryList()
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, len(countries), 249)
+
+	tests := []struct {
+		index   int
+		country Country
+	}{
+		{
+			index: 8,
+			country: Country{
+				Code: "ARG",
+				Name: "Argentina",
+			},
+		},
+		{
+			index: 189,
+			country: Country{
+				Code: "RUS",
+				Name: "Russian Federation",
+			},
+		},
+		{
+			index: 234,
+			country: Country{
+				Code: "USA",
+				Name: "United States of America",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("Check country code=%s", tt.country.Code), func(t *testing.T) {
+			assert.DeepEqual(t, *countries[tt.index], tt.country)
+		})
+	}
+}

--- a/internal/data/countries_test.go
+++ b/internal/data/countries_test.go
@@ -52,3 +52,66 @@ func TestGetCountryList(t *testing.T) {
 		})
 	}
 }
+
+func TestGetCountry(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	tests := []struct {
+		name        string
+		countryCode string
+		country     Country
+	}{
+		{
+			name:        "Valid uppercase code (AUT)",
+			countryCode: "AUT",
+			country: Country{
+				Code: "AUT",
+				Name: "Austria",
+			},
+		},
+		{
+			name:        "Valid mixed case code (Mex)",
+			countryCode: "Mex",
+			country: Country{
+				Code: "MEX",
+				Name: "Mexico",
+			},
+		},
+		{
+			name:        "Valid lowercase code (srb)",
+			countryCode: "srb",
+			country: Country{
+				Code: "SRB",
+				Name: "Serbia",
+			},
+		},
+		{
+			name:        "Nonexistent country code (XXXX)",
+			countryCode: "xxxx",
+		},
+		{
+			name:        "Non-alphabetic code (123)",
+			countryCode: "123",
+		},
+		{
+			name:        "Empty country code",
+			countryCode: "",
+		},
+		{
+			name:        "Code with 1 letter (a)",
+			countryCode: "a",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			country, err := models.Countries.GetCountry(tt.countryCode)
+			if err != nil {
+				assert.Equal(t, err, ErrRecordNotFound)
+				return
+			}
+			assert.DeepEqual(t, *country, tt.country)
+		})
+	}
+}

--- a/internal/data/filters.go
+++ b/internal/data/filters.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"regexp"
+	"strconv"
 
 	"github.com/denis-k2/relohelper-go/internal/validator"
 )
@@ -13,4 +14,15 @@ type Filters struct {
 func ValidateFilters(v *validator.Validator, f Filters) {
 	countryCodeRegex := regexp.MustCompile(`^[A-Za-z]{3}$`)
 	v.Check(countryCodeRegex.MatchString(f.CountryCode), "country_code", "must be exactly three English letters")
+}
+
+func ValidateBoolQuery(v *validator.Validator, s string) bool {
+	if s != "" {
+		boolQueryValue, err := strconv.ParseBool(s)
+		if err != nil {
+			v.Check(false, "query parameter", "must be a boolean value")
+		}
+		return boolQueryValue
+	}
+	return false
 }

--- a/internal/data/filters.go
+++ b/internal/data/filters.go
@@ -1,0 +1,16 @@
+package data
+
+import (
+	"regexp"
+
+	"github.com/denis-k2/relohelper-go/internal/validator"
+)
+
+type Filters struct {
+	CountryCode string
+}
+
+func ValidateFilters(v *validator.Validator, f Filters) {
+	countryCodeRegex := regexp.MustCompile(`^[A-Za-z]{3}$`)
+	v.Check(countryCodeRegex.MatchString(f.CountryCode), "country_code", "must be exactly three English letters")
+}

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -11,11 +11,13 @@ var (
 )
 
 type Models struct {
-	Cities CityModel
+	Cities    CityModel
+	Countries CountryModel
 }
 
 func NewModels(db *sql.DB) Models {
 	return Models{
-		Cities: CityModel{DB: db},
+		Cities:    CityModel{DB: db},
+		Countries: CountryModel{DB: db},
 	}
 }

--- a/internal/data/models.go
+++ b/internal/data/models.go
@@ -1,0 +1,21 @@
+package data
+
+import (
+	"database/sql"
+	"errors"
+)
+
+var (
+	ErrRecordNotFound = errors.New("record not found")
+	ErrEditConflict   = errors.New("edit conflict")
+)
+
+type Models struct {
+	Cities CityModel
+}
+
+func NewModels(db *sql.DB) Models {
+	return Models{
+		Cities: CityModel{DB: db},
+	}
+}

--- a/internal/data/testutils_test.go
+++ b/internal/data/testutils_test.go
@@ -1,0 +1,22 @@
+package data
+
+import (
+	"database/sql"
+	"flag"
+	"os"
+	"testing"
+)
+
+var testDBdsn = flag.String("db-dsn", os.Getenv("RELOHELPER_TEST_DB_DSN"), "PostgreSQL DSN for testing")
+
+// Stub flag to allow passing cmd flag during testing.
+var _ = flag.String("env", "", "Environment flag for testing")
+
+func newTestDB(t *testing.T) *sql.DB {
+	db, err := sql.Open("postgres", *testDBdsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return db
+}

--- a/internal/validator/validator.go
+++ b/internal/validator/validator.go
@@ -1,0 +1,25 @@
+package validator
+
+type Validator struct {
+	Errors map[string]string
+}
+
+func New() *Validator {
+	return &Validator{Errors: make(map[string]string)}
+}
+
+func (v *Validator) Valid() bool {
+	return len(v.Errors) == 0
+}
+
+func (v *Validator) AddError(key, message string) {
+	if _, exists := v.Errors[key]; !exists {
+		v.Errors[key] = message
+	}
+}
+
+func (v *Validator) Check(ok bool, key, message string) {
+	if !ok {
+		v.AddError(key, message)
+	}
+}


### PR DESCRIPTION
## Changes
- Implemented base endpoints for cities and countries data
- Added query parameters support for nested resources
- Covered main scenarios with unit/integration tests

## Endpoints
| Method | Path                 | Description                            |
| ------ | -------------------- | -------------------------------------- |
| GET    | `/cities`            | List cities (filter by `country_code`) |
| GET    | `/cities/:id`        | City details with optional data        |
| GET    | `/countries`         | List countries                         |
| GET    | `/countries/:alpha3` | Country details with optional data     |

Extended query string parameters have been implemented for the following endpoints:

- `GET /cities?country_code=ABC`: Filter cities by country (`alpha3` country code).
- `GET /cities/:id?numbeo_cost=t&numbeo_indices=t&avg_climate=t`: Retrieve city details with optional numbeo cost, indices, and climate data.
- `GET /countries/:alpha3?numbeo_indices=t&legatum_indices=t`: Retrieve country details with optional numbeo and legatum indices.

## Notes
- Uses ISO 3166-1 alpha3 country codes
- Boolean parameters accept `1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False`