### PR TITLE
feat: enhanced error handling, panic recovery & rate limiting

### DIFF
--- a/cmd/api/errors.go
+++ b/cmd/api/errors.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 )
 
@@ -37,4 +38,9 @@ func (app *application) notFoundResponse(w http.ResponseWriter, r *http.Request)
 
 func (app *application) failedValidationResponse(w http.ResponseWriter, r *http.Request, errors map[string]string) {
 	app.errorResponse(w, r, http.StatusUnprocessableEntity, errors)
+}
+
+func (app *application) methodNotAllowedResponse(w http.ResponseWriter, r *http.Request) {
+	message := fmt.Sprintf("the %s method is not supported for this resource", r.Method)
+	app.errorResponse(w, r, http.StatusMethodNotAllowed, message)
 }

--- a/cmd/api/errors.go
+++ b/cmd/api/errors.go
@@ -44,3 +44,8 @@ func (app *application) methodNotAllowedResponse(w http.ResponseWriter, r *http.
 	message := fmt.Sprintf("the %s method is not supported for this resource", r.Method)
 	app.errorResponse(w, r, http.StatusMethodNotAllowed, message)
 }
+
+func (app *application) rateLimitExceededResponse(w http.ResponseWriter, r *http.Request) {
+	message := "rate limit exceeded"
+	app.errorResponse(w, r, http.StatusTooManyRequests, message)
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -29,6 +29,11 @@ type config struct {
 		maxIdleConns int
 		maxIdleTime  time.Duration
 	}
+	limiter struct {
+		rps     float64
+		burst   int
+		enabled bool
+	}
 }
 
 type application struct {
@@ -76,6 +81,10 @@ func parseFlags() (config, error) {
 	flag.IntVar(&cfg.db.maxOpenConns, "db-max-open-conns", 25, "PostgreSQL max open connections")
 	flag.IntVar(&cfg.db.maxIdleConns, "db-max-idle-conns", 25, "PostgreSQL max idle connections")
 	flag.DurationVar(&cfg.db.maxIdleTime, "db-max-idle-time", 15*time.Minute, "PostgreSQL max connection idle time")
+
+	flag.Float64Var(&cfg.limiter.rps, "limiter-rps", 10, "Rate limiter maximum requests per second")
+	flag.IntVar(&cfg.limiter.burst, "limiter-burst", 20, "Rate limiter maximum burst")
+	flag.BoolVar(&cfg.limiter.enabled, "limiter-enabled", true, "Enable rate limiter")
 
 	displayVersion := flag.Bool("version", false, "Display version and exit")
 

--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func (app *application) recoverPanic(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer func() {
+			if err := recover(); err != nil {
+				w.Header().Set("Connection", "close")
+				app.serverErrorResponse(w, r, fmt.Errorf("%s", err))
+			}
+		}()
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -2,7 +2,12 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
 )
 
 func (app *application) recoverPanic(next http.Handler) http.Handler {
@@ -13,6 +18,64 @@ func (app *application) recoverPanic(next http.Handler) http.Handler {
 				app.serverErrorResponse(w, r, fmt.Errorf("%s", err))
 			}
 		}()
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (app *application) rateLimit(next http.Handler) http.Handler {
+	type client struct {
+		limiter  *rate.Limiter
+		lastSeen time.Time
+	}
+
+	var (
+		mu      sync.Mutex
+		clients = make(map[string]*client)
+	)
+
+	go func() {
+		for {
+			time.Sleep(time.Minute)
+
+			mu.Lock()
+
+			for ip, client := range clients {
+				if time.Since(client.lastSeen) > 3*time.Minute {
+					delete(clients, ip)
+				}
+			}
+
+			mu.Unlock()
+		}
+	}()
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if app.config.limiter.enabled {
+			ip, _, err := net.SplitHostPort(r.RemoteAddr)
+			if err != nil {
+				app.serverErrorResponse(w, r, err)
+				return
+			}
+
+			mu.Lock()
+
+			if _, found := clients[ip]; !found {
+				clients[ip] = &client{
+					limiter: rate.NewLimiter(rate.Limit(app.config.limiter.rps), app.config.limiter.burst),
+				}
+			}
+
+			clients[ip].lastSeen = time.Now()
+
+			if !clients[ip].limiter.Allow() {
+				mu.Unlock()
+				app.rateLimitExceededResponse(w, r)
+				return
+			}
+
+			mu.Unlock()
+		}
 
 		next.ServeHTTP(w, r)
 	})

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -18,5 +18,5 @@ func (app *application) routes() http.Handler {
 	router.HandlerFunc(http.MethodGet, "/countries", app.listCountriesHandler)
 	router.HandlerFunc(http.MethodGet, "/countries/:alpha3", app.showCountryHandler)
 
-	return app.recoverPanic(router)
+	return app.recoverPanic(app.rateLimit(router))
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -18,5 +18,5 @@ func (app *application) routes() http.Handler {
 	router.HandlerFunc(http.MethodGet, "/countries", app.listCountriesHandler)
 	router.HandlerFunc(http.MethodGet, "/countries/:alpha3", app.showCountryHandler)
 
-	return router
+	return app.recoverPanic(router)
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -8,6 +8,8 @@ import (
 
 func (app *application) routes() http.Handler {
 	router := httprouter.New()
+	router.NotFound = http.HandlerFunc(app.notFoundResponse)
+	router.MethodNotAllowed = http.HandlerFunc(app.methodNotAllowedResponse)
 
 	router.HandlerFunc(http.MethodGet, "/healthcheck", app.healthcheckHandler)
 

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -99,6 +99,28 @@ func (ts *testServer) get(t *testing.T, urlPath string) (int, http.Header, []byt
 	return rs.StatusCode, rs.Header, body
 }
 
+// sendRequest universal method for sending requests with any HTTP method
+func (ts *testServer) sendRequest(t *testing.T, method string, urlPath string, body io.Reader) (int, http.Header, []byte) {
+	req, err := http.NewRequest(method, ts.URL+urlPath, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rs, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer rs.Body.Close()
+	responseBody, err := io.ReadAll(rs.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	responseBody = bytes.TrimSpace(responseBody)
+
+	return rs.StatusCode, rs.Header, responseBody
+}
+
 func unmarshalJSON(t *testing.T, body []byte, gotPtr any) {
 	err := json.Unmarshal(body, gotPtr)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,9 @@
 module github.com/denis-k2/relohelper-go
 
-go 1.24.0
+go 1.24.1
 
 require github.com/julienschmidt/httprouter v1.3.0
 
 require github.com/lib/pq v1.10.9
+
+require golang.org/x/time v0.11.0

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4d
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+golang.org/x/time v0.11.0 h1:/bpjEDfN9tkoN/ryeYHnv5hcMlc8ncjMcM4XBk5NWV0=
+golang.org/x/time v0.11.0/go.mod h1:CDIdPxbZBQxdj6cxyCIdrNogrJKMJ7pr37NYpMcMDSg=


### PR DESCRIPTION
This pull request contains improvements to our API server infrastructure:

- **HTTP Routing Error Handlers**
Added handlers for 404 (Not Found) and 405 (Method Not Allowed) errors that return JSON responses in a standardized format.
- **Panic Recovery Middleware**
Implemented recoverPanic() middleware that catches panics in API handlers, logs errors via our structured logger using app.serverErrorResponse(), and responds with a standardized 500 Internal Server Error in JSON format.
- **IP-based Rate Limiting**
Added middleware to limit request rates by IP, contributing to preventing potential overload scenarios.