### PR TITLE
Refactor/errcheck and run cleanup

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"expvar"
 	"flag"
 	"fmt"
@@ -146,7 +147,9 @@ func openDB(cfg config) (*sql.DB, error) {
 
 	err = db.PingContext(ctx)
 	if err != nil {
-		db.Close() //nolint:errcheck
+		if closeErr := db.Close(); closeErr != nil {
+			return nil, errors.Join(err, closeErr)
+		}
 		return nil, err
 	}
 

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -56,19 +56,29 @@ type application struct {
 }
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "server startup failed: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
 	cfg, err := parseFlags()
 	if err != nil {
-		os.Exit(1)
+		return err
 	}
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 
 	db, err := openDB(cfg)
 	if err != nil {
-		logger.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
-	defer db.Close() //nolint:errcheck
+	defer func() {
+		if err := db.Close(); err != nil {
+			logger.Error("failed to close database connection pool", "error", err)
+		}
+	}()
 	logger.Info("database connection pool established")
 
 	registerMetrics(version, db)
@@ -82,9 +92,10 @@ func main() {
 
 	err = app.serve()
 	if err != nil {
-		logger.Error(err.Error())
-		os.Exit(1)
+		return err
 	}
+
+	return nil
 }
 
 func parseFlags() (config, error) {

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -1,4 +1,3 @@
-//nolint:errcheck
 package main
 
 import (
@@ -101,7 +100,11 @@ func (ts *testServer) get(t *testing.T, urlPath string) (int, http.Header, []byt
 		t.Fatal(err)
 	}
 
-	defer rs.Body.Close()
+	defer func() {
+		if err := rs.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	}()
 	body, err := io.ReadAll(rs.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -133,7 +136,11 @@ func (ts *testServer) sendRequest(t *testing.T, method string, urlPath string, h
 		t.Fatal(err)
 	}
 
-	defer rs.Body.Close()
+	defer func() {
+		if err := rs.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	}()
 	responseBody, err := io.ReadAll(rs.Body)
 	if err != nil {
 		t.Fatal(err)
@@ -192,13 +199,13 @@ func setupUsersTable(t *testing.T) {
 	t.Helper()
 	script, err := os.ReadFile("../../migrations/000001_create_users_table.up.sql")
 	if err != nil {
-		testDB.Close()
+		closeTestDB(t)
 		t.Fatal(err)
 	}
 
 	_, err = testDB.Exec(string(script))
 	if err != nil {
-		testDB.Close()
+		closeTestDB(t)
 		t.Fatal(err)
 	}
 }
@@ -207,13 +214,13 @@ func teardownUsersTable(t *testing.T) {
 	t.Helper()
 	script, err := os.ReadFile("../../migrations/000001_create_users_table.down.sql")
 	if err != nil {
-		testDB.Close()
+		closeTestDB(t)
 		t.Fatal(err)
 	}
 
 	_, err = testDB.Exec(string(script))
 	if err != nil {
-		testDB.Close()
+		closeTestDB(t)
 		t.Fatal(err)
 	}
 }
@@ -222,13 +229,13 @@ func setupTokensTable(t *testing.T) {
 	t.Helper()
 	script, err := os.ReadFile("../../migrations/000002_create_tokens_table.up.sql")
 	if err != nil {
-		testDB.Close()
+		closeTestDB(t)
 		t.Fatal(err)
 	}
 
 	_, err = testDB.Exec(string(script))
 	if err != nil {
-		testDB.Close()
+		closeTestDB(t)
 		t.Fatal(err)
 	}
 }
@@ -237,13 +244,21 @@ func teardownTokensTable(t *testing.T) {
 	t.Helper()
 	script, err := os.ReadFile("../../migrations/000002_create_tokens_table.down.sql")
 	if err != nil {
-		testDB.Close()
+		closeTestDB(t)
 		t.Fatal(err)
 	}
 
 	_, err = testDB.Exec(string(script))
 	if err != nil {
-		testDB.Close()
+		closeTestDB(t)
 		t.Fatal(err)
+	}
+}
+
+func closeTestDB(t *testing.T) {
+	t.Helper()
+
+	if err := testDB.Close(); err != nil {
+		t.Logf("failed to close test DB: %v", err)
 	}
 }

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -106,7 +106,7 @@ type CityModel struct {
 	DB *sql.DB
 }
 
-func (c CityModel) GetCityList(countryСode string) ([]*City, error) {
+func (c CityModel) GetCityList(countryСode string) (cities []*City, retErr error) {
 	query := `
         SELECT city_id, city, state_code, country_code
 		FROM city
@@ -120,9 +120,13 @@ func (c CityModel) GetCityList(countryСode string) ([]*City, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close() //nolint:errcheck
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
-	cities := []*City{}
+	cities = []*City{}
 
 	dataFound := false
 	for rows.Next() {
@@ -189,13 +193,13 @@ func (c CityModel) GetCityID(id int64) (*City, error) {
 	return &city, nil
 }
 
-func (c CityModel) GetNumbeoCost(id int64) (*CostDetails, error) {
+func (c CityModel) GetNumbeoCost(id int64) (result *CostDetails, retErr error) {
 	if id < 1 {
 		return nil, ErrRecordNotFound
 	}
 
 	query := `
-		SELECT 
+		SELECT
         	nc.category,
         	np.param,
         	ns.cost,
@@ -203,7 +207,7 @@ func (c CityModel) GetNumbeoCost(id int64) (*CostDetails, error) {
 			upper(ns.range) AS upper_bound,
 			ns.currency,
         	to_char(ns.updated_date, 'YYYY-MM-DD')
-		FROM numbeo_stat ns 
+		FROM numbeo_stat ns
 		JOIN numbeo_param np ON ns.param_id = np.param_id
 		JOIN numbeo_category nc ON np.category_id = nc.category_id
 		WHERE ns.city_id = $1;`
@@ -217,7 +221,11 @@ func (c CityModel) GetNumbeoCost(id int64) (*CostDetails, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close() //nolint:errcheck
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	dataFound := false
 	for rows.Next() {
@@ -246,7 +254,9 @@ func (c CityModel) GetNumbeoCost(id int64) (*CostDetails, error) {
 		return nil, ErrRecordNotFound
 	}
 
-	return &cost, nil
+	result = &cost
+
+	return result, nil
 }
 
 func (c CityModel) GetNumbeoIndicies(id int64) (*Indices, error) {
@@ -305,7 +315,7 @@ func (c CityModel) GetNumbeoIndicies(id int64) (*Indices, error) {
 	return &index, nil
 }
 
-func (c CityModel) GetAvgClimatePivot(id int64) (*AvgClimate, error) {
+func (c CityModel) GetAvgClimatePivot(id int64) (result *AvgClimate, retErr error) {
 	if id < 1 {
 		return nil, ErrRecordNotFound
 	}
@@ -338,7 +348,11 @@ func (c CityModel) GetAvgClimatePivot(id int64) (*AvgClimate, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close() //nolint:errcheck
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	dataFound := false
 	for rows.Next() {
@@ -409,5 +423,7 @@ func (c CityModel) GetAvgClimatePivot(id int64) (*AvgClimate, error) {
 		return nil, ErrRecordNotFound
 	}
 
-	return &climate, nil
+	result = &climate
+
+	return result, nil
 }

--- a/internal/data/countries.go
+++ b/internal/data/countries.go
@@ -88,7 +88,7 @@ type CountryModel struct {
 	DB *sql.DB
 }
 
-func (c CountryModel) GetCountryList() ([]*Country, error) {
+func (c CountryModel) GetCountryList() (countries []*Country, retErr error) {
 	query := `
         SELECT country_code, country
 		FROM country
@@ -101,9 +101,13 @@ func (c CountryModel) GetCountryList() ([]*Country, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close() //nolint:errcheck
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
-	countries := []*Country{}
+	countries = []*Country{}
 
 	for rows.Next() {
 		var country Country
@@ -210,9 +214,9 @@ func (c CountryModel) GetNumbeoCountryIndicies(country_code string) (*NumbeoCoun
 	return &index, nil
 }
 
-func (c CountryModel) GetLegatumIndicies(country_code string) (*LegatumCountryIndices, error) {
+func (c CountryModel) GetLegatumIndicies(country_code string) (result *LegatumCountryIndices, retErr error) {
 	query := `
-	SELECT 
+	SELECT
 		pillar_name,
 		rank_2007, rank_2008, rank_2009, rank_2010, rank_2011, rank_2012, rank_2013, rank_2014,
 		rank_2015, rank_2016, rank_2017, rank_2018, rank_2019, rank_2020, rank_2021, rank_2022, rank_2023,
@@ -230,7 +234,11 @@ func (c CountryModel) GetLegatumIndicies(country_code string) (*LegatumCountryIn
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close() //nolint:errcheck
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
 
 	dataFound := false
 	for rows.Next() {
@@ -315,5 +323,7 @@ func (c CountryModel) GetLegatumIndicies(country_code string) (*LegatumCountryIn
 		return nil, ErrRecordNotFound
 	}
 
-	return &legatum, nil
+	result = &legatum
+
+	return result, nil
 }


### PR DESCRIPTION
## Summary
Refactor startup flow to make deferred cleanup reliable.

## Changes
- Moved application bootstrap logic from `main()` to `run() error`.
- Kept `main()` minimal: calls `run()` and exits with non-zero code on error.
- Replaced direct startup `os.Exit(...)` paths with returned errors.
- Added explicit `db.Close()` error handling in deferred cleanup.

## Why
Previously, deferred cleanup could be skipped on `os.Exit`, which makes resource cleanup behavior less reliable.  
This refactor ensures cleanup runs on normal error paths and keeps process exit control in one place (`main()`).