### PR TITLE
chore: upgrade Go version and fix internal docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ This project focuses on:
 - Performance-oriented implementation
 - Reproducible load testing
 
-The original Python implementation can be found here:
-https://github.com/denis-k2/relohelper
+The original Python implementation can be found [here](https://github.com/denis-k2/relohelper).
 
 ## Documentation
 
@@ -23,7 +22,7 @@ Project documentation is located in the `docs/` directory:
 - `docs/architecture/` — system structure and design
 - `docs/performance/` — load testing methodology and benchmark runs
 
-Performance comparison between Go and Python implementations is documented [here](https://github.com/denis-k2/relohelper-go/docs/performance/runs/2025-04-22_compare-go-v0.1.0_py-v0.3.0/README.md).
+Performance comparison between Go and Python implementations is documented [here](./docs/performance/runs/2025-04-22_compare-go-v0.1.0_py-v0.3.0/README.md).
 
 ## Current Status
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/denis-k2/relohelper-go
 
-go 1.24.1
+go 1.26.0
 
 require github.com/julienschmidt/httprouter v1.3.0
 


### PR DESCRIPTION
Summary
- Upgraded project Go version to latest stable.
- Updated module/toolchain settings in `go.mod`.
- Fixed internal documentation links to use relative paths (work both on GitHub and locally).

## Changes
- `go.mod`: updated `go`.
- Dependency metadata refreshed (`go mod tidy`).
- `README`/docs: replaced absolute repo-local GitHub link with relative link.

## Validation
- `go version` shows new version.
- Project builds and tests pass (`make test`).
- Updated links open correctly from GitHub and local repo viewer.