### PR TITLE
refactor: migrate API router from httprouter to chi

### DIFF
--- a/cmd/api/countries.go
+++ b/cmd/api/countries.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
+	"github.com/go-chi/chi/v5"
 
 	"github.com/denis-k2/relohelper-go/internal/data"
 	"github.com/denis-k2/relohelper-go/internal/validator"
@@ -34,7 +34,7 @@ func (app *application) showCountryHandler(w http.ResponseWriter, r *http.Reques
 	v := validator.New()
 	qs := r.URL.Query()
 
-	input.CountryCode = httprouter.ParamsFromContext(r.Context()).ByName("alpha3")
+	input.CountryCode = chi.URLParam(r, "alpha3")
 	input.numbeoCountryIndices = app.readString(qs, "numbeo_indices", "")
 	input.legatumIndices = app.readString(qs, "legatum_indices", "")
 	numbeoIndicesEnabled := data.ValidateBoolQuery(v, input.numbeoCountryIndices)

--- a/cmd/api/helpers.go
+++ b/cmd/api/helpers.go
@@ -11,15 +11,13 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/julienschmidt/httprouter"
+	"github.com/go-chi/chi/v5"
 )
 
 type envelope map[string]any
 
 func (app *application) readIDParam(r *http.Request) (int64, error) {
-	params := httprouter.ParamsFromContext(r.Context())
-
-	id, err := strconv.ParseInt(params.ByName("id"), 10, 64)
+	id, err := strconv.ParseInt(chi.URLParam(r, "id"), 10, 64)
 	if err != nil || id < 1 {
 		return 0, errors.New("invalid id parameter")
 	}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -4,26 +4,28 @@ import (
 	"expvar"
 	"net/http"
 
-	"github.com/julienschmidt/httprouter"
+	"github.com/go-chi/chi/v5"
 )
 
 func (app *application) routes() http.Handler {
-	router := httprouter.New()
-	router.NotFound = http.HandlerFunc(app.notFoundResponse)
-	router.MethodNotAllowed = http.HandlerFunc(app.methodNotAllowedResponse)
+	router := chi.NewRouter()
+	router.NotFound(app.notFoundResponse)
+	router.MethodNotAllowed(app.methodNotAllowedResponse)
 
-	router.HandlerFunc(http.MethodGet, "/healthcheck", app.healthcheckHandler)
+	router.Get("/healthcheck", app.healthcheckHandler)
 
-	router.HandlerFunc(http.MethodGet, "/cities", app.listCitiesHandler)
-	router.HandlerFunc(http.MethodGet, "/cities/:id", app.requireActivatedUser(app.showCityHandler))
-	router.HandlerFunc(http.MethodGet, "/countries", app.listCountriesHandler)
-	router.HandlerFunc(http.MethodGet, "/countries/:alpha3", app.requireActivatedUser(app.showCountryHandler))
+	router.Get("/cities", app.listCitiesHandler)
+	router.Get("/cities/{id}", app.requireActivatedUser(app.showCityHandler))
+	router.Get("/countries", app.listCountriesHandler)
+	router.Get("/countries/{alpha3}", app.requireActivatedUser(app.showCountryHandler))
 
-	router.HandlerFunc(http.MethodPost, "/users", app.registerUserHandler)
-	router.HandlerFunc(http.MethodPut, "/users/activated", app.activateUserHandler)
-	router.HandlerFunc(http.MethodPost, "/tokens/authentication", app.createAuthenticationTokenHandler)
+	router.Post("/users", app.registerUserHandler)
+	router.Put("/users/activated", app.activateUserHandler)
+	router.Post("/tokens/authentication", app.createAuthenticationTokenHandler)
 
-	router.Handler(http.MethodGet, "/debug/vars", expvar.Handler())
+	router.Get("/debug/vars", func(w http.ResponseWriter, r *http.Request) {
+		expvar.Handler().ServeHTTP(w, r)
+	})
 
 	return app.recoverPanic(app.enableCORS(app.rateLimit(app.authenticate(router))))
 }

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -217,7 +217,7 @@ func TestCityID(t *testing.T) {
 		{
 			name:       "Empty ID",
 			urlPath:    "/cities/",
-			statusCode: http.StatusOK,
+			statusCode: http.StatusNotFound,
 		},
 	}
 
@@ -449,7 +449,7 @@ func TestCountry(t *testing.T) {
 		{
 			name:       "Empty country code",
 			urlPath:    "/countries/",
-			statusCode: http.StatusOK,
+			statusCode: http.StatusNotFound,
 		},
 		{
 			name:       "Code with 1 letter (a)",

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/denis-k2/relohelper-go
 
 go 1.26.0
 
-require github.com/julienschmidt/httprouter v1.3.0
+require github.com/go-chi/chi/v5 v5.2.3
 
 require github.com/lib/pq v1.10.9
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
+github.com/go-chi/chi/v5 v5.2.3 h1:WQIt9uxdsAbgIYgid+BpYc+liqQZGMHRaUwp0JUcvdE=
+github.com/go-chi/chi/v5 v5.2.3/go.mod h1:L2yAIGWB3H+phAw1NxKwWM+7eUH/lU8pOMm5hHcoops=
 github.com/go-mail/mail/v2 v2.3.0 h1:wha99yf2v3cpUzD1V9ujP404Jbw2uEvs+rBJybkdYcw=
 github.com/go-mail/mail/v2 v2.3.0/go.mod h1:oE2UK8qebZAjjV1ZYUpY7FPnbi/kIU53l1dmqPRb4go=
-github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=


### PR DESCRIPTION
## Summary
Replaced `httprouter` with `chi` in the API layer.

## Changes
- Switched router implementation in `cmd/api/routes.go` to `chi`.
- Updated route patterns from `:param` to `{param}`.
- Replaced path param reads with `chi.URLParam(...)`.
- Updated module dependency from `github.com/julienschmidt/httprouter` to `github.com/go-chi/chi/v5`.
- Standardized trailing-slash behavior for collection endpoints:
  - `/cities/` -> 404
  - `/countries/` -> 404
- Updated tests accordingly.

## Why
`chi` gives a more modern and flexible routing model while keeping handlers/middleware structure simple and idiomatic.

## Validation
- `go mod tidy`
- `make test`