### PR TITLE
refactor: finalize idiomatic chi routing and harden debug endpoint exposure

### DIFF
--- a/cmd/api/middleware.go
+++ b/cmd/api/middleware.go
@@ -129,7 +129,7 @@ func (app *application) authenticate(next http.Handler) http.Handler {
 	})
 }
 
-func (app *application) requireActivatedUser(next http.HandlerFunc) http.HandlerFunc {
+func (app *application) requireActivatedUser(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user := app.contextGetUser(r)
 

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -20,17 +20,17 @@ func (app *application) routes() http.Handler {
 	router.Get("/healthcheck", app.healthcheckHandler)
 
 	router.Get("/cities", app.listCitiesHandler)
-	router.Get("/cities/{id}", app.requireActivatedUser(app.showCityHandler))
+	router.With(app.requireActivatedUser).Get("/cities/{id}", app.showCityHandler)
 	router.Get("/countries", app.listCountriesHandler)
-	router.Get("/countries/{alpha3}", app.requireActivatedUser(app.showCountryHandler))
+	router.With(app.requireActivatedUser).Get("/countries/{alpha3}", app.showCountryHandler)
 
 	router.Post("/users", app.registerUserHandler)
 	router.Put("/users/activated", app.activateUserHandler)
 	router.Post("/tokens/authentication", app.createAuthenticationTokenHandler)
 
-	router.Get("/debug/vars", func(w http.ResponseWriter, r *http.Request) {
-		expvar.Handler().ServeHTTP(w, r)
-	})
+	if app.config.env != "production" {
+		router.Method(http.MethodGet, "/debug/vars", expvar.Handler())
+	}
 
 	return router
 }

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -9,6 +9,11 @@ import (
 
 func (app *application) routes() http.Handler {
 	router := chi.NewRouter()
+	router.Use(app.recoverPanic)
+	router.Use(app.enableCORS)
+	router.Use(app.rateLimit)
+	router.Use(app.authenticate)
+
 	router.NotFound(app.notFoundResponse)
 	router.MethodNotAllowed(app.methodNotAllowedResponse)
 
@@ -27,5 +32,5 @@ func (app *application) routes() http.Handler {
 		expvar.Handler().ServeHTTP(w, r)
 	})
 
-	return app.recoverPanic(app.enableCORS(app.rateLimit(app.authenticate(router))))
+	return router
 }


### PR DESCRIPTION
## Summary
Completed the `chi` routing cleanup by making middleware/route wiring idiomatic and restricting debug endpoint exposure in production.

## Changes
- Registered global middleware via `router.Use(...)`:
  - `recoverPanic`
  - `enableCORS`
  - `rateLimit`
  - `authenticate`
- Converted `requireActivatedUser` to standard middleware signature:
  - `func(http.Handler) http.Handler`
- Applied activation guard using `router.With(...)` on protected routes:
  - `GET /cities/{id}`
  - `GET /countries/{alpha3}`
- Replaced the anonymous expvar handler with explicit route registration:
  - `router.Method(http.MethodGet, "/debug/vars", expvar.Handler())`
- Restricted `/debug/vars` to non-production environments:
  - route is registered only when `env != "production"`.

## Why
- Align routing code with idiomatic `chi` patterns.
- Make middleware composition easier to read and maintain.
- Reduce risk of exposing sensitive/debug runtime information in production.

## Validation
- `make test`
