### PR TITLE
refactor(config): move batch ids limit to app config

### DIFF
--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -13,7 +13,29 @@ func (app *application) listCitiesHandler(w http.ResponseWriter, r *http.Request
 	v := validator.New()
 	qs := r.URL.Query()
 
-	if len(qs) > 0 {
+	err := validateAllowedQueryParams(qs, newIncludeSet("country_code", "include", "ids"))
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
+		return
+	}
+
+	_, err = parseInclude(qs, newIncludeSet("country"))
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"include": err.Error()})
+		return
+	}
+
+	_, idsPresent, err := parseIDsInt64(qs, "ids", 100)
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"ids": err.Error()})
+		return
+	}
+	if idsPresent {
+		app.errorResponse(w, r, http.StatusNotImplemented, "batch retrieval for cities by ids is not implemented yet")
+		return
+	}
+
+	if qs.Has("country_code") {
 		input.CountryCode = app.readString(qs, "country_code", "")
 		if data.ValidateFilters(v, input); !v.Valid() {
 			app.failedValidationResponse(w, r, v.Errors)
@@ -47,23 +69,22 @@ func (app *application) showCityHandler(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	var input struct {
-		numbeoCost    string
-		numbeoIndices string
-		avgClimate    string
-	}
-	v := validator.New()
 	qs := r.URL.Query()
-	input.numbeoCost = app.readString(qs, "numbeo_cost", "")
-	input.numbeoIndices = app.readString(qs, "numbeo_indices", "")
-	input.avgClimate = app.readString(qs, "avg_climate", "")
-	costEnabled := data.ValidateBoolQuery(v, input.numbeoCost)
-	indicesEnabled := data.ValidateBoolQuery(v, input.numbeoIndices)
-	climateEnabled := data.ValidateBoolQuery(v, input.avgClimate)
-	if !v.Valid() {
-		app.failedValidationResponse(w, r, v.Errors)
+	err = validateAllowedQueryParams(qs, newIncludeSet("include"))
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
 		return
 	}
+
+	include, err := parseInclude(qs, newIncludeSet("country", "numbeo_cost", "numbeo_indices", "avg_climate"))
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"include": err.Error()})
+		return
+	}
+
+	costEnabled := include.Has("numbeo_cost")
+	indicesEnabled := include.Has("numbeo_indices")
+	climateEnabled := include.Has("avg_climate")
 
 	city, err := app.models.Cities.GetCityID(id)
 	if err != nil {

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -25,7 +25,7 @@ func (app *application) listCitiesHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	_, idsPresent, err := parseIDsInt64(qs, "ids", 100)
+	_, idsPresent, err := parseIDsInt64(qs, "ids", app.config.batch.maxIDs)
 	if err != nil {
 		app.failedValidationResponse(w, r, map[string]string{"ids": err.Error()})
 		return

--- a/cmd/api/countries.go
+++ b/cmd/api/countries.go
@@ -24,7 +24,7 @@ func (app *application) listCountriesHandler(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	_, idsPresent, err := parseIDsString(qs, "country_codes", 100)
+	_, idsPresent, err := parseIDsString(qs, "country_codes", app.config.batch.maxIDs)
 	if err != nil {
 		app.failedValidationResponse(w, r, map[string]string{"country_codes": err.Error()})
 		return

--- a/cmd/api/countries.go
+++ b/cmd/api/countries.go
@@ -11,6 +11,29 @@ import (
 )
 
 func (app *application) listCountriesHandler(w http.ResponseWriter, r *http.Request) {
+	qs := r.URL.Query()
+
+	err := validateAllowedQueryParams(qs, newIncludeSet("country_codes", "include"))
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
+		return
+	}
+
+	if qs.Has("include") {
+		app.failedValidationResponse(w, r, map[string]string{"include": "include is not supported for countries list endpoint"})
+		return
+	}
+
+	_, idsPresent, err := parseIDsString(qs, "country_codes", 100)
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"country_codes": err.Error()})
+		return
+	}
+	if idsPresent {
+		app.errorResponse(w, r, http.StatusNotImplemented, "batch retrieval for countries by country_codes is not implemented yet")
+		return
+	}
+
 	countries, err := app.models.Countries.GetCountryList()
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
@@ -28,17 +51,25 @@ func (app *application) listCountriesHandler(w http.ResponseWriter, r *http.Requ
 func (app *application) showCountryHandler(w http.ResponseWriter, r *http.Request) {
 	var input struct {
 		data.Filters
-		numbeoCountryIndices string
-		legatumIndices       string
 	}
 	v := validator.New()
 	qs := r.URL.Query()
+	err := validateAllowedQueryParams(qs, newIncludeSet("include"))
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
+		return
+	}
 
 	input.CountryCode = chi.URLParam(r, "alpha3")
-	input.numbeoCountryIndices = app.readString(qs, "numbeo_indices", "")
-	input.legatumIndices = app.readString(qs, "legatum_indices", "")
-	numbeoIndicesEnabled := data.ValidateBoolQuery(v, input.numbeoCountryIndices)
-	legatumIndicesEnabled := data.ValidateBoolQuery(v, input.legatumIndices)
+	include, err := parseInclude(qs, newIncludeSet("numbeo_indices", "legatum_indices"))
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"include": err.Error()})
+		return
+	}
+
+	numbeoIndicesEnabled := include.Has("numbeo_indices")
+	legatumIndicesEnabled := include.Has("legatum_indices")
+
 	if data.ValidateFilters(v, input.Filters); !v.Valid() {
 		app.failedValidationResponse(w, r, v.Errors)
 		return

--- a/cmd/api/healthcheck.go
+++ b/cmd/api/healthcheck.go
@@ -5,6 +5,12 @@ import (
 )
 
 func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
+	err := validateAllowedQueryParams(r.URL.Query(), newIncludeSet())
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
+		return
+	}
+
 	env := envelope{
 		"status": "available",
 		"system_info": map[string]string{
@@ -13,7 +19,7 @@ func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Reques
 		},
 	}
 
-	err := app.writeJSON(w, http.StatusOK, env, nil)
+	err = app.writeJSON(w, http.StatusOK, env, nil)
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 	}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -39,6 +39,9 @@ type config struct {
 		burst   int
 		enabled bool
 	}
+	batch struct {
+		maxIDs int
+	}
 	smtp struct {
 		host     string
 		port     int
@@ -113,6 +116,7 @@ func parseFlags() (config, error) {
 	flag.Float64Var(&cfg.limiter.rps, "limiter-rps", 10, "Rate limiter maximum requests per second")
 	flag.IntVar(&cfg.limiter.burst, "limiter-burst", 20, "Rate limiter maximum burst")
 	flag.BoolVar(&cfg.limiter.enabled, "limiter-enabled", true, "Enable rate limiter")
+	flag.IntVar(&cfg.batch.maxIDs, "batch-max-ids", 100, "Maximum number of unique IDs in batch query parameters")
 
 	flag.StringVar(&cfg.smtp.host, "smtp-host", os.Getenv("RELOHELPER_SMTP_HOST"), "SMTP host")
 	flag.IntVar(&cfg.smtp.port, "smtp-port", 25, "SMTP port")

--- a/cmd/api/query_params.go
+++ b/cmd/api/query_params.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type IncludeSet map[string]struct{}
+
+func newIncludeSet(values ...string) IncludeSet {
+	set := make(IncludeSet, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+
+	return set
+}
+
+func (s IncludeSet) Has(value string) bool {
+	_, ok := s[value]
+	return ok
+}
+
+func validateAllowedQueryParams(qs url.Values, allowed IncludeSet) error {
+	if len(qs) == 0 {
+		return nil
+	}
+
+	keys := make([]string, 0, len(qs))
+	for key := range qs {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		if !allowed.Has(key) {
+			return fmt.Errorf("unknown query parameter %q", key)
+		}
+	}
+
+	return nil
+}
+
+func parseInclude(qs url.Values, allowed IncludeSet) (IncludeSet, error) {
+	raw := strings.TrimSpace(qs.Get("include"))
+	if raw == "" {
+		return newIncludeSet(), nil
+	}
+
+	include := newIncludeSet()
+	for _, token := range strings.Split(raw, ",") {
+		item := strings.ToLower(strings.TrimSpace(token))
+		if item == "" {
+			return nil, fmt.Errorf("include contains an empty value")
+		}
+		if !allowed.Has(item) {
+			return nil, fmt.Errorf("include contains unsupported value %q", item)
+		}
+
+		include[item] = struct{}{}
+	}
+
+	return include, nil
+}
+
+func parseIDsInt64(qs url.Values, key string, max int) ([]int64, bool, error) {
+	if key == "" {
+		return nil, false, fmt.Errorf("query parameter key must be provided")
+	}
+	if max <= 0 {
+		max = 100
+	}
+
+	if !qs.Has(key) {
+		return nil, false, nil
+	}
+	raw := strings.TrimSpace(qs.Get(key))
+	if raw == "" {
+		return nil, true, fmt.Errorf("%s contains an empty value", key)
+	}
+
+	ids := make([]int64, 0)
+	seen := make(map[int64]struct{})
+
+	for _, token := range strings.Split(raw, ",") {
+		item := strings.TrimSpace(token)
+		if item == "" {
+			return nil, true, fmt.Errorf("%s contains an empty value", key)
+		}
+
+		id, err := strconv.ParseInt(item, 10, 64)
+		if err != nil {
+			return nil, true, fmt.Errorf("%s contains non-integer value %q", key, item)
+		}
+		if id <= 0 {
+			return nil, true, fmt.Errorf("%s must contain only positive integers", key)
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+		if len(ids) > max {
+			return nil, true, fmt.Errorf("%s cannot contain more than %d unique values", key, max)
+		}
+	}
+
+	return ids, true, nil
+}
+
+func parseIDsString(qs url.Values, key string, max int) ([]string, bool, error) {
+	if key == "" {
+		return nil, false, fmt.Errorf("query parameter key must be provided")
+	}
+	if max <= 0 {
+		max = 100
+	}
+
+	if !qs.Has(key) {
+		return nil, false, nil
+	}
+	raw := strings.TrimSpace(qs.Get(key))
+	if raw == "" {
+		return nil, true, fmt.Errorf("%s contains an empty value", key)
+	}
+
+	ids := make([]string, 0)
+	seen := make(map[string]struct{})
+
+	for _, token := range strings.Split(raw, ",") {
+		item := strings.ToUpper(strings.TrimSpace(token))
+		if item == "" {
+			return nil, true, fmt.Errorf("%s contains an empty value", key)
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+
+		seen[item] = struct{}{}
+		ids = append(ids, item)
+		if len(ids) > max {
+			return nil, true, fmt.Errorf("%s cannot contain more than %d unique values", key, max)
+		}
+	}
+
+	return ids, true, nil
+}

--- a/cmd/api/query_params_test.go
+++ b/cmd/api/query_params_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+)
+
+// TestParseInclude tests the include query parameter parser.
+func TestParseInclude(t *testing.T) {
+	t.Run("empty include", func(t *testing.T) {
+		got, err := parseInclude(url.Values{}, newIncludeSet("country"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected empty set, got %v", got)
+		}
+	})
+
+	t.Run("normalize and dedupe", func(t *testing.T) {
+		qs := url.Values{"include": []string{" country,NUMBEO_COST, country "}}
+		got, err := parseInclude(qs, newIncludeSet("country", "numbeo_cost"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !got.Has("country") || !got.Has("numbeo_cost") || len(got) != 2 {
+			t.Fatalf("unexpected include set: %v", got)
+		}
+	})
+
+	t.Run("unsupported value", func(t *testing.T) {
+		qs := url.Values{"include": []string{"country,foo"}}
+		_, err := parseInclude(qs, newIncludeSet("country"))
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("empty token", func(t *testing.T) {
+		qs := url.Values{"include": []string{"country, ,numbeo_cost"}}
+		_, err := parseInclude(qs, newIncludeSet("country", "numbeo_cost"))
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+}
+
+// TestParseIDsInt64 tests parsing and validation for integer ids query parameter.
+func TestParseIDsInt64(t *testing.T) {
+	t.Run("not present", func(t *testing.T) {
+		got, present, err := parseIDsInt64(url.Values{}, "ids", 200)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if present {
+			t.Fatal("expected present=false")
+		}
+		if got != nil {
+			t.Fatalf("expected nil ids, got %v", got)
+		}
+	})
+
+	t.Run("parse normalize dedupe", func(t *testing.T) {
+		qs := url.Values{"ids": []string{"1, 2,2,3 "}}
+		got, present, err := parseIDsInt64(qs, "ids", 200)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !present {
+			t.Fatal("expected present=true")
+		}
+		want := []int64{1, 2, 3}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("present but empty", func(t *testing.T) {
+		qs := url.Values{"ids": []string{""}}
+		_, present, err := parseIDsInt64(qs, "ids", 200)
+		if !present {
+			t.Fatal("expected present=true")
+		}
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("reject non positive", func(t *testing.T) {
+		qs := url.Values{"ids": []string{"0,2"}}
+		_, _, err := parseIDsInt64(qs, "ids", 200)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("reject non integer", func(t *testing.T) {
+		qs := url.Values{"ids": []string{"1,a"}}
+		_, _, err := parseIDsInt64(qs, "ids", 200)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("reject empty token", func(t *testing.T) {
+		qs := url.Values{"ids": []string{"1,,2"}}
+		_, _, err := parseIDsInt64(qs, "ids", 200)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("enforce max", func(t *testing.T) {
+		qs := url.Values{"ids": []string{"1,2,3"}}
+		_, _, err := parseIDsInt64(qs, "ids", 2)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("empty key is invalid", func(t *testing.T) {
+		_, _, err := parseIDsInt64(url.Values{}, "", 2)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+}
+
+// TestParseIDsString tests parsing and validation for string ids query parameter.
+func TestParseIDsString(t *testing.T) {
+	t.Run("not present", func(t *testing.T) {
+		got, present, err := parseIDsString(url.Values{}, "ids", 200)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if present {
+			t.Fatal("expected present=false")
+		}
+		if got != nil {
+			t.Fatalf("expected nil ids, got %v", got)
+		}
+	})
+
+	t.Run("normalize uppercase dedupe", func(t *testing.T) {
+		qs := url.Values{"ids": []string{"rus, usa ,RUS"}}
+		got, present, err := parseIDsString(qs, "ids", 200)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !present {
+			t.Fatal("expected present=true")
+		}
+		want := []string{"RUS", "USA"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("present but empty", func(t *testing.T) {
+		qs := url.Values{"ids": []string{""}}
+		_, present, err := parseIDsString(qs, "ids", 200)
+		if !present {
+			t.Fatal("expected present=true")
+		}
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("reject empty token", func(t *testing.T) {
+		qs := url.Values{"ids": []string{"RUS,,USA"}}
+		_, _, err := parseIDsString(qs, "ids", 200)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("enforce max", func(t *testing.T) {
+		qs := url.Values{"ids": []string{"RUS,USA,CAN"}}
+		_, _, err := parseIDsString(qs, "ids", 2)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+
+	t.Run("empty key is invalid", func(t *testing.T) {
+		_, _, err := parseIDsString(url.Values{}, "", 2)
+		if err == nil {
+			t.Fatal("expected validation error")
+		}
+	})
+}

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -183,8 +183,8 @@ func TestCityID(t *testing.T) {
 			},
 		},
 		{
-			name:       "Valid ID with False & extra query params",
-			urlPath:    "/cities/273?numbeo_cost=false&numbeo_indices=0&avg_climate=&extra_param=true",
+			name:       "Valid ID with include query",
+			urlPath:    "/cities/273?include=country",
 			statusCode: http.StatusOK,
 			city: data.City{
 				CityID:      273,
@@ -251,7 +251,7 @@ func TestCityIDandQuery(t *testing.T) {
 	}{
 		{
 			name:       "One param enabled",
-			urlPath:    "/cities/12?numbeo_cost=true",
+			urlPath:    "/cities/12?include=numbeo_cost",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    true,
@@ -261,7 +261,7 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 		{
 			name:       "Two params enabled",
-			urlPath:    "/cities/123?numbeo_cost=1&numbeo_indices=TRUE&avg_climate=f",
+			urlPath:    "/cities/123?include=numbeo_cost,numbeo_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    true,
@@ -271,7 +271,7 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 		{
 			name:       "All params enabled",
-			urlPath:    "/cities/456?numbeo_cost=t&numbeo_indices=1&avg_climate=True",
+			urlPath:    "/cities/456?include=numbeo_cost,numbeo_indices,avg_climate",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    true,
@@ -281,7 +281,7 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 		{
 			name:       "Enable both params with missing Avg Climate data",
-			urlPath:    "/cities/329?numbeo_cost=t&numbeo_indices=1&avg_climate=t",
+			urlPath:    "/cities/329?include=numbeo_cost,numbeo_indices,avg_climate",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    true,
@@ -290,8 +290,8 @@ func TestCityIDandQuery(t *testing.T) {
 			},
 		},
 		{
-			name:       "One param with false value",
-			urlPath:    "/cities/321?numbeo_indices=0",
+			name:       "Include country only",
+			urlPath:    "/cities/321?include=country",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    false,
@@ -302,31 +302,26 @@ func TestCityIDandQuery(t *testing.T) {
 		{
 			name:       "Unknown params (mixed cases)",
 			urlPath:    "/cities/123?NUMBEO_COST=1&Numbeo_Indices=true&InvalidParam=TRUE",
-			statusCode: http.StatusOK,
-			queryParams: queryParamsCity{
-				costEnabled:    false, // Upper case parameter not recognized
-				indicesEnabled: false, // CamelCase parameter not recognized
-				climateEnabled: false,
-			},
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:       "Duplicate params",
-			urlPath:    "/cities/234?numbeo_cost=false&numbeo_cost=true&avg_climate=1",
+			name:       "Duplicate includes",
+			urlPath:    "/cities/234?include=numbeo_cost,numbeo_cost,avg_climate",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
-				costEnabled:    false,
+				costEnabled:    true,
 				indicesEnabled: false,
 				climateEnabled: true,
 			},
 		},
 		{
-			name:       "Unprocessable query value (123)",
-			urlPath:    "/cities/100?numbeo_cost=123",
+			name:       "Unprocessable include value (123)",
+			urlPath:    "/cities/100?include=123",
 			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:       "Unprocessable query value (abc)",
-			urlPath:    "/cities/100?numbeo_cost=abc",
+			name:       "Unprocessable include value (abc)",
+			urlPath:    "/cities/100?include=abc",
 			statusCode: http.StatusUnprocessableEntity,
 		},
 	}
@@ -343,7 +338,17 @@ func TestCityIDandQuery(t *testing.T) {
 
 			if tt.statusCode == http.StatusUnprocessableEntity {
 				wantError := map[string]any{
-					"query parameter": "must be a boolean value",
+					"include": "include contains unsupported value \"123\"",
+				}
+				if tt.name == "Unprocessable include value (abc)" {
+					wantError = map[string]any{
+						"include": "include contains unsupported value \"abc\"",
+					}
+				}
+				if tt.name == "Unknown params (mixed cases)" {
+					wantError = map[string]any{
+						"query": "unknown query parameter \"InvalidParam\"",
+					}
 				}
 				assert.DeepEqual(t, got.Error, wantError)
 			}
@@ -514,7 +519,7 @@ func TestCountryandQuery(t *testing.T) {
 	}{
 		{
 			name:       "Enable only Numbeo indices",
-			urlPath:    "/countries/rus?numbeo_indices=true",
+			urlPath:    "/countries/rus?include=numbeo_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  true,
@@ -523,7 +528,7 @@ func TestCountryandQuery(t *testing.T) {
 		},
 		{
 			name:       "Enable only Legatum indices",
-			urlPath:    "/countries/usa?legatum_indices=TRUE",
+			urlPath:    "/countries/usa?include=legatum_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
@@ -532,7 +537,7 @@ func TestCountryandQuery(t *testing.T) {
 		},
 		{
 			name:       "Enable all params (Numbeo and Legatum)",
-			urlPath:    "/countries/bra?numbeo_indices=1&legatum_indices=True",
+			urlPath:    "/countries/bra?include=numbeo_indices,legatum_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  true,
@@ -541,7 +546,7 @@ func TestCountryandQuery(t *testing.T) {
 		},
 		{
 			name:       "Enable both params with missing Numbeo data",
-			urlPath:    "/countries/afg?numbeo_indices=t&legatum_indices=true",
+			urlPath:    "/countries/afg?include=numbeo_indices,legatum_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
@@ -550,7 +555,7 @@ func TestCountryandQuery(t *testing.T) {
 		},
 		{
 			name:       "Enable both params with missing both data",
-			urlPath:    "/countries/wlf?numbeo_indices=t&legatum_indices=t",
+			urlPath:    "/countries/wlf?include=numbeo_indices,legatum_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
@@ -558,8 +563,8 @@ func TestCountryandQuery(t *testing.T) {
 			},
 		},
 		{
-			name:       "Disable only Numbeo indices",
-			urlPath:    "/countries/can?numbeo_indices=0",
+			name:       "Include empty",
+			urlPath:    "/countries/can?include=",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
@@ -569,29 +574,25 @@ func TestCountryandQuery(t *testing.T) {
 		{
 			name:       "Unknown params (mixed cases)",
 			urlPath:    "/countries/arg?Numbeo_Indices=true&LEGATHUM_INDICES=1&InvalidParam=TRUE",
-			statusCode: http.StatusOK,
-			queryParams: queryParamsCountry{
-				numbeoIndicesEnabled:  false, // CamelCase parameter not recognized
-				legatumIndicesEnabled: false, // Upper case parameter not recognized
-			},
+			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:       "Duplicate params",
-			urlPath:    "/countries/chn?numbeo_indices=false&numbeo_indices=true&legatum_indices=1",
+			name:       "Duplicate includes",
+			urlPath:    "/countries/chn?include=numbeo_indices,numbeo_indices,legatum_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCountry{
-				numbeoIndicesEnabled:  false,
+				numbeoIndicesEnabled:  true,
 				legatumIndicesEnabled: true,
 			},
 		},
 		{
-			name:       "Unprocessable query value (123)",
-			urlPath:    "/countries/deu?numbeo_indices=123",
+			name:       "Unprocessable include value (123)",
+			urlPath:    "/countries/deu?include=123",
 			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			name:       "Unprocessable query value (abc)",
-			urlPath:    "/countries/nld?numbeo_indices=abc",
+			name:       "Unprocessable include value (abc)",
+			urlPath:    "/countries/nld?include=abc",
 			statusCode: http.StatusUnprocessableEntity,
 		},
 	}
@@ -608,10 +609,58 @@ func TestCountryandQuery(t *testing.T) {
 
 			if tt.statusCode == http.StatusUnprocessableEntity {
 				wantError := map[string]any{
-					"query parameter": "must be a boolean value",
+					"include": "include contains unsupported value \"123\"",
+				}
+				if tt.name == "Unprocessable include value (abc)" {
+					wantError = map[string]any{
+						"include": "include contains unsupported value \"abc\"",
+					}
+				}
+				if tt.name == "Unknown params (mixed cases)" {
+					wantError = map[string]any{
+						"query": "unknown query parameter \"InvalidParam\"",
+					}
 				}
 				assert.DeepEqual(t, got.Error, wantError)
 			}
+		})
+	}
+}
+
+// TestUnknownQueryParams tests that all endpoints reject unknown query parameters.
+func TestUnknownQueryParams(t *testing.T) {
+	ts := newTestServerWithMockUser(testApp.routes())
+	defer ts.Close()
+
+	tests := []struct {
+		name       string
+		method     string
+		urlPath    string
+		headers    http.Header
+		statusCode int
+	}{
+		{name: "healthcheck", method: http.MethodGet, urlPath: "/healthcheck?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
+		{name: "cities list", method: http.MethodGet, urlPath: "/cities?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
+		{name: "cities detail", method: http.MethodGet, urlPath: "/cities/15?foo=bar", headers: mocks.Headers, statusCode: http.StatusUnprocessableEntity},
+		{name: "countries list", method: http.MethodGet, urlPath: "/countries?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
+		{name: "countries detail", method: http.MethodGet, urlPath: "/countries/AUS?foo=bar", headers: mocks.Headers, statusCode: http.StatusUnprocessableEntity},
+		{name: "register user", method: http.MethodPost, urlPath: "/users?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
+		{name: "activate user", method: http.MethodPut, urlPath: "/users/activated?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
+		{name: "authentication token", method: http.MethodPost, urlPath: "/tokens/authentication?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			statusCode, header, body := ts.sendRequest(t, tt.method, tt.urlPath, tt.headers, nil)
+			assert.Equal(t, statusCode, tt.statusCode)
+			assert.Equal(t, header.Get("content-type"), "application/json")
+
+			var got gotResponse
+			unmarshalJSON(t, body, &got)
+			wantError := map[string]any{
+				"query": "unknown query parameter \"foo\"",
+			}
+			assert.DeepEqual(t, got.Error, wantError)
 		})
 	}
 }

--- a/cmd/api/tokens.go
+++ b/cmd/api/tokens.go
@@ -10,12 +10,18 @@ import (
 )
 
 func (app *application) createAuthenticationTokenHandler(w http.ResponseWriter, r *http.Request) {
+	err := validateAllowedQueryParams(r.URL.Query(), newIncludeSet())
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
+		return
+	}
+
 	var input struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`
 	}
 
-	err := app.readJSON(w, r, &input)
+	err = app.readJSON(w, r, &input)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return

--- a/cmd/api/users.go
+++ b/cmd/api/users.go
@@ -10,8 +10,14 @@ import (
 )
 
 func (app *application) registerUserHandler(w http.ResponseWriter, r *http.Request) {
+	err := validateAllowedQueryParams(r.URL.Query(), newIncludeSet())
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
+		return
+	}
+
 	var input data.InputUser
-	err := app.readJSON(w, r, &input)
+	err = app.readJSON(w, r, &input)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return
@@ -72,11 +78,17 @@ func (app *application) registerUserHandler(w http.ResponseWriter, r *http.Reque
 }
 
 func (app *application) activateUserHandler(w http.ResponseWriter, r *http.Request) {
+	err := validateAllowedQueryParams(r.URL.Query(), newIncludeSet())
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
+		return
+	}
+
 	var input struct {
 		TokenPlaintext string `json:"token"`
 	}
 
-	err := app.readJSON(w, r, &input)
+	err = app.readJSON(w, r, &input)
 	if err != nil {
 		app.badRequestResponse(w, r, err)
 		return


### PR DESCRIPTION
## Summary
Moved batch IDs limit from hardcoded handler values to application configuration.

## Changes
- Added batch config section in `cmd/api/main.go`:
  - `cfg.batch.maxIDs`
- Added CLI flag:
  - `-batch-max-ids` (default: `100`)
- Updated handlers to use configured limit:
  - `cmd/api/cities.go` -> `parseIDsInt64(..., app.config.batch.maxIDs)`
  - `cmd/api/countries.go` -> `parseIDsString(..., app.config.batch.maxIDs)`

## Why
- Removes magic numbers from handlers.
- Makes batch limits explicit and configurable per environment.
- Keeps parsing/validation behavior unchanged while improving maintainability.

## Validation
- `make test`
