### PR TITLE
refactor(data): return avg_climate as fixed 12-point arrays

### DIFF
--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/lib/pq"
@@ -52,57 +53,41 @@ type Indices struct {
 }
 
 type AvgClimate struct {
-	HighTemp     MonthlyValue      `json:"high_temp"`
-	LowTemp      MonthlyValue      `json:"low_temp"`
-	Pressure     MonthlyValue      `json:"pressure"`
-	WindSpeed    MonthlyValue      `json:"wind_speed"`
-	Humidity     MonthlyValue      `json:"humidity"`
-	Rainfall     MonthlyValue      `json:"rainfall"`
-	RainfallDays MonthlyValue      `json:"rainfall_days"`
-	Snowfall     MonthlyValue      `json:"snowfall"`
-	SnowfallDays MonthlyValue      `json:"snowfall_days"`
-	SeaTemp      MonthlyValue      `json:"sea_temp"`
-	Daylight     MonthlyValue      `json:"daylight"`
-	Sunshine     MonthlyValue      `json:"sunshine"`
-	SunshineDays MonthlyValue      `json:"sunshine_days"`
-	UVIndex      MonthlyValue      `json:"uv_index"`
-	CloudCover   MonthlyValue      `json:"cloud_cover"`
-	Visibility   MonthlyValue      `json:"visibility"`
-	Measures     map[string]string `json:"measures"`
+	HighTemp     [12]*float64 `json:"high_temp"`
+	LowTemp      [12]*float64 `json:"low_temp"`
+	Pressure     [12]*float64 `json:"pressure"`
+	WindSpeed    [12]*float64 `json:"wind_speed"`
+	Humidity     [12]*float64 `json:"humidity"`
+	Rainfall     [12]*float64 `json:"rainfall"`
+	RainfallDays [12]*float64 `json:"rainfall_days"`
+	Snowfall     [12]*float64 `json:"snowfall"`
+	SnowfallDays [12]*float64 `json:"snowfall_days"`
+	SeaTemp      [12]*float64 `json:"sea_temp"`
+	Daylight     [12]*float64 `json:"daylight"`
+	Sunshine     [12]*float64 `json:"sunshine"`
+	SunshineDays [12]*float64 `json:"sunshine_days"`
+	UVIndex      [12]*float64 `json:"uv_index"`
+	CloudCover   [12]*float64 `json:"cloud_cover"`
+	Visibility   [12]*float64 `json:"visibility"`
 }
 
-type MonthlyValue struct {
-	January   *float64 `json:"january"`
-	February  *float64 `json:"february"`
-	March     *float64 `json:"march"`
-	April     *float64 `json:"april"`
-	May       *float64 `json:"may"`
-	June      *float64 `json:"june"`
-	July      *float64 `json:"july"`
-	August    *float64 `json:"august"`
-	September *float64 `json:"september"`
-	October   *float64 `json:"october"`
-	November  *float64 `json:"november"`
-	December  *float64 `json:"december"`
-}
-
-var measures = map[string]string{
-	"high_temp":     "Average high temperature, °C",
-	"low_temp":      "Average low temperature, °C",
-	"pressure":      "Average pressure, mbar",
-	"wind_speed":    "Average wind speed, km/h",
-	"humidity":      "Average humidity, %",
-	"rainfall":      "Average rainfall, mm",
-	"rainfall_days": "Average rainfall days, days",
-	"snowfall":      "Average snowfall, mm",
-	"snowfall_days": "Average snowfall days, days",
-	"sea_temp":      "Average sea temperature, °C",
-	"daylight":      "Average daylight, hours",
-	"sunshine":      "Average sunshine, hours",
-	"sunshine_days": "Average sunshine days, days",
-	"uv_index":      "Average UV index",
-	"cloud_cover":   "Average cloud cover, %",
-	"visibility":    "Average visibility, km",
+type avgClimateRaw struct {
+	HighTemp     []*float64 `json:"high_temp"`
+	LowTemp      []*float64 `json:"low_temp"`
+	Pressure     []*float64 `json:"pressure"`
+	WindSpeed    []*float64 `json:"wind_speed"`
+	Humidity     []*float64 `json:"humidity"`
+	Rainfall     []*float64 `json:"rainfall"`
+	RainfallDays []*float64 `json:"rainfall_days"`
+	Snowfall     []*float64 `json:"snowfall"`
+	SnowfallDays []*float64 `json:"snowfall_days"`
+	SeaTemp      []*float64 `json:"sea_temp"`
+	Daylight     []*float64 `json:"daylight"`
+	Sunshine     []*float64 `json:"sunshine"`
+	SunshineDays []*float64 `json:"sunshine_days"`
+	UVIndex      []*float64 `json:"uv_index"`
+	CloudCover   []*float64 `json:"cloud_cover"`
+	Visibility   []*float64 `json:"visibility"`
 }
 
 type CityModel struct {
@@ -220,39 +205,43 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 			END AS numbeo_indices,
 			CASE
 				WHEN $5 THEN (
-					SELECT jsonb_object_agg(metric_key, month_values)
-					FROM (
+					WITH climate_rows AS (
+						SELECT *
+						FROM avg_climate ac
+						WHERE ac.city_id = c.city_id
+					),
+					climate_stats AS (
+						SELECT
+							COUNT(*) AS row_count,
+							COUNT(DISTINCT month) AS unique_month_count,
+							MIN(month) AS min_month,
+							MAX(month) AS max_month
+						FROM climate_rows
+					),
+					climate_data AS (
 						SELECT
 							m.metric_key,
-							jsonb_object_agg(
-								CASE ac.month
-									WHEN 1 THEN 'january'
-									WHEN 2 THEN 'february'
-									WHEN 3 THEN 'march'
-									WHEN 4 THEN 'april'
-									WHEN 5 THEN 'may'
-									WHEN 6 THEN 'june'
-									WHEN 7 THEN 'july'
-									WHEN 8 THEN 'august'
-									WHEN 9 THEN 'september'
-									WHEN 10 THEN 'october'
-									WHEN 11 THEN 'november'
-									WHEN 12 THEN 'december'
-								END,
-								m.metric_value
-								ORDER BY ac.month
-							) AS month_values
-						FROM avg_climate ac
+							jsonb_agg(m.metric_value ORDER BY cr.month) AS month_values
+						FROM climate_rows cr
 						CROSS JOIN LATERAL jsonb_each(
-							to_jsonb(ac)
+							to_jsonb(cr)
 								- 'city_id'
 								- 'month'
 								- 'sys_updated_date'
 								- 'sys_updeted_by'
 						) AS m(metric_key, metric_value)
-						WHERE ac.city_id = c.city_id
 						GROUP BY m.metric_key
-					) AS climate_data
+					)
+					SELECT
+						CASE
+							WHEN s.row_count = 12
+								AND s.unique_month_count = 12
+								AND s.min_month = 1
+								AND s.max_month = 12
+							THEN (SELECT jsonb_object_agg(metric_key, month_values) FROM climate_data)
+							ELSE jsonb_build_object('__invalid_structure__', true)
+						END
+					FROM climate_stats s
 				)
 				ELSE NULL
 			END AS avg_climate
@@ -312,12 +301,11 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 	}
 
 	if len(climateJSON) > 0 && string(climateJSON) != "null" {
-		var climate AvgClimate
-		if err := json.Unmarshal(climateJSON, &climate); err != nil {
+		climate, err := decodeAvgClimateSeries(id, climateJSON)
+		if err != nil {
 			return nil, err
 		}
-		climate.Measures = measures
-		city.AvgClimate = &climate
+		city.AvgClimate = climate
 	}
 
 	return &city, nil
@@ -372,4 +360,61 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 	}
 
 	return cities, nil
+}
+
+func decodeAvgClimateSeries(cityID int64, rawJSON []byte) (*AvgClimate, error) {
+	var raw avgClimateRaw
+	if err := json.Unmarshal(rawJSON, &raw); err != nil {
+		return nil, err
+	}
+
+	series := map[string][]*float64{
+		"high_temp":     raw.HighTemp,
+		"low_temp":      raw.LowTemp,
+		"pressure":      raw.Pressure,
+		"wind_speed":    raw.WindSpeed,
+		"humidity":      raw.Humidity,
+		"rainfall":      raw.Rainfall,
+		"rainfall_days": raw.RainfallDays,
+		"snowfall":      raw.Snowfall,
+		"snowfall_days": raw.SnowfallDays,
+		"sea_temp":      raw.SeaTemp,
+		"daylight":      raw.Daylight,
+		"sunshine":      raw.Sunshine,
+		"sunshine_days": raw.SunshineDays,
+		"uv_index":      raw.UVIndex,
+		"cloud_cover":   raw.CloudCover,
+		"visibility":    raw.Visibility,
+	}
+
+	for metric, values := range series {
+		if len(values) != 12 {
+			return nil, fmt.Errorf("invalid avg_climate series for city_id=%d metric=%s: got %d values, expected 12", cityID, metric, len(values))
+		}
+	}
+
+	return &AvgClimate{
+		HighTemp:     toMonthArray(raw.HighTemp),
+		LowTemp:      toMonthArray(raw.LowTemp),
+		Pressure:     toMonthArray(raw.Pressure),
+		WindSpeed:    toMonthArray(raw.WindSpeed),
+		Humidity:     toMonthArray(raw.Humidity),
+		Rainfall:     toMonthArray(raw.Rainfall),
+		RainfallDays: toMonthArray(raw.RainfallDays),
+		Snowfall:     toMonthArray(raw.Snowfall),
+		SnowfallDays: toMonthArray(raw.SnowfallDays),
+		SeaTemp:      toMonthArray(raw.SeaTemp),
+		Daylight:     toMonthArray(raw.Daylight),
+		Sunshine:     toMonthArray(raw.Sunshine),
+		SunshineDays: toMonthArray(raw.SunshineDays),
+		UVIndex:      toMonthArray(raw.UVIndex),
+		CloudCover:   toMonthArray(raw.CloudCover),
+		Visibility:   toMonthArray(raw.Visibility),
+	}, nil
+}
+
+func toMonthArray(values []*float64) [12]*float64 {
+	var result [12]*float64
+	copy(result[:], values)
+	return result
 }

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -234,6 +234,8 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 					)
 					SELECT
 						CASE
+							WHEN s.row_count = 0
+							THEN NULL
 							WHEN s.row_count = 12
 								AND s.unique_month_count = 12
 								AND s.min_month = 1

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -100,7 +100,11 @@ func TestGetCityAvgClimateOrderedByMonth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			t.Fatalf("failed to close rows: %v", err)
+		}
+	}()
 
 	for rows.Next() {
 		var (

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -1,6 +1,7 @@
 package data
 
 import (
+	"database/sql"
 	"testing"
 
 	_ "github.com/lib/pq"
@@ -63,4 +64,108 @@ func TestGetCitiesByIDs(t *testing.T) {
 	assert.Equal(t, cities[0].CityID, int64(11))
 	assert.Equal(t, cities[0].Country != "", true)
 	assert.Equal(t, cities[1].CityID, int64(94))
+}
+
+func TestGetCityAvgClimateOrderedByMonth(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	var cityID int64
+	err := db.QueryRow(`
+		SELECT city_id
+		FROM avg_climate
+		GROUP BY city_id
+		HAVING COUNT(*) = 12
+		LIMIT 1;
+	`).Scan(&cityID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("testing city_id=%d", cityID)
+
+	city, err := models.Cities.GetCity(cityID, NewIncludeSet("avg_climate"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if city.AvgClimate == nil {
+		t.Fatal("expected avg_climate to be present")
+	}
+
+	expected := make([]*float64, 12)
+	rows, err := db.Query(`
+		SELECT month, high_temp
+		FROM avg_climate
+		WHERE city_id = $1
+		ORDER BY month;`, cityID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			month int
+			value sql.NullFloat64
+		)
+		if err := rows.Scan(&month, &value); err != nil {
+			t.Fatal(err)
+		}
+		if value.Valid {
+			v := value.Float64
+			expected[month-1] = &v
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, len(city.AvgClimate.HighTemp), 12)
+	for i := range expected {
+		if !equalFloatPtrs(expected[i], city.AvgClimate.HighTemp[i]) {
+			t.Fatalf("city_id=%d high_temp[%d] mismatch: got=%v want=%v", cityID, i, city.AvgClimate.HighTemp[i], expected[i])
+		}
+	}
+}
+
+func TestGetCityAvgClimateSeaTempAllNull(t *testing.T) {
+	db := newTestDB(t)
+	models := NewModels(db)
+
+	var cityID int64
+	err := db.QueryRow(`
+		SELECT city_id
+		FROM avg_climate
+		GROUP BY city_id
+		HAVING COUNT(*) = 12 AND COUNT(sea_temp) = 0
+		LIMIT 1;
+	`).Scan(&cityID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("testing city_id=%d", cityID)
+
+	city, err := models.Cities.GetCity(cityID, NewIncludeSet("avg_climate"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if city.AvgClimate == nil {
+		t.Fatal("expected avg_climate to be present")
+	}
+
+	assert.Equal(t, len(city.AvgClimate.SeaTemp), 12)
+	for i, value := range city.AvgClimate.SeaTemp {
+		if value != nil {
+			t.Fatalf("city_id=%d expected sea_temp[%d] to be nil, got %v", cityID, i, *value)
+		}
+	}
+}
+
+func equalFloatPtrs(a, b *float64) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
 }


### PR DESCRIPTION
## Summary
Refactors city detail climate payload to a chart-friendly fixed-series format and hardens climate data handling for missing/invalid monthly rows.

## Changes
- changed `avg_climate` response shape to `metric -> array[12]` (`index = month-1`)
- switched `AvgClimate` domain model to fixed-length arrays (`[12]*float64`) with strict decode path
- implemented ordered SQL aggregation by month for each metric (`jsonb_agg(... ORDER BY month)`)
- added structural month-set validation in SQL (`count/distinct/min/max`) for climate rows
- fixed missing climate case: when no `avg_climate` rows exist for a city, return `avg_climate: null` (when included) instead of `500`
- added/updated data-layer tests for ordering and `sea_temp` all-null behavior
- fixed test lint issue by handling `rows.Close()` error explicitly

## API contract
- `avg_climate` no longer uses month-name keys; metrics are now arrays of 12 values (`number|null`)
- other city fields remain unchanged

## Verification
- `make test`