### PR TITLE
refactor(data): align domain naming with project schema

### DIFF
--- a/cmd/api/response_mappers.go
+++ b/cmd/api/response_mappers.go
@@ -15,8 +15,8 @@ type cityResponse struct {
 
 func newCityResponse(city *data.City, include data.IncludeSet) cityResponse {
 	res := cityResponse{
-		CityID:      city.CityID,
-		City:        city.City,
+		CityID:      city.ID,
+		City:        city.Name,
 		StateCode:   city.StateCode,
 		CountryCode: city.CountryCode,
 		Country:     city.Country,
@@ -26,7 +26,7 @@ func newCityResponse(city *data.City, include data.IncludeSet) cityResponse {
 		res.NumbeoCost = city.NumbeoCost
 	}
 	if include.Has("numbeo_indices") {
-		res.NumbeoIndices = city.NumbeoIndices
+		res.NumbeoIndices = city.NumbeoCityIndices
 	}
 	if include.Has("avg_climate") {
 		res.AvgClimate = city.AvgClimate
@@ -49,10 +49,10 @@ func newCountryResponse(country *data.Country, include data.IncludeSet) countryR
 	}
 
 	if include.Has("numbeo_indices") {
-		res.NumbeoIndices = country.NumbeoIndices
+		res.NumbeoIndices = country.NumbeoCountryIndices
 	}
 	if include.Has("legatum_indices") {
-		res.LegatumIndices = country.LegatumIndices
+		res.LegatumIndices = country.LegatumCountryIndices
 	}
 
 	return res

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -42,26 +42,26 @@ func TestCities(t *testing.T) {
 
 	wantCities := []data.City{
 		{
-			CityID:      11,
-			City:        "New York",
+			ID:          11,
+			Name:        "New York",
 			StateCode:   ptrString("US-NY"),
 			CountryCode: "USA",
 		},
 		{
-			CityID:      94,
-			City:        "Toronto",
+			ID:          94,
+			Name:        "Toronto",
 			StateCode:   nil,
 			CountryCode: "CAN",
 		},
 		{
-			CityID:      464,
-			City:        "Moscow",
+			ID:          464,
+			Name:        "Moscow",
 			StateCode:   nil,
 			CountryCode: "RUS",
 		},
 	}
 	for _, city := range wantCities {
-		assert.DeepEqual(t, got.Cities[city.CityID-1], city)
+		assert.DeepEqual(t, got.Cities[city.ID-1], city)
 	}
 }
 
@@ -172,8 +172,8 @@ func TestCitiesBatchByIDs(t *testing.T) {
 	var got gotResponse
 	unmarshalJSON(t, body, &got)
 	assert.Equal(t, len(got.Cities), 2)
-	assert.Equal(t, got.Cities[0].CityID, int64(11))
-	assert.Equal(t, got.Cities[1].CityID, int64(94))
+	assert.Equal(t, got.Cities[0].ID, int64(11))
+	assert.Equal(t, got.Cities[1].ID, int64(94))
 }
 
 // TestCity tests the “/cities/:id” endpoint.
@@ -192,8 +192,8 @@ func TestCityID(t *testing.T) {
 			urlPath:    "/cities/15",
 			statusCode: http.StatusOK,
 			city: data.City{
-				CityID:      15,
-				City:        "Seattle",
+				ID:          15,
+				Name:        "Seattle",
 				StateCode:   ptrString("US-WA"),
 				CountryCode: "USA",
 				Country:     "United States of America",
@@ -204,8 +204,8 @@ func TestCityID(t *testing.T) {
 			urlPath:    "/cities/273?include=country",
 			statusCode: http.StatusOK,
 			city: data.City{
-				CityID:      273,
-				City:        "Tokyo",
+				ID:          273,
+				Name:        "Tokyo",
 				StateCode:   nil,
 				CountryCode: "JPN",
 				Country:     "Japan",

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -178,7 +178,7 @@ type queryParamsCity struct {
 func cityFildsToBool(c data.City) queryParamsCity {
 	return queryParamsCity{
 		costEnabled:    c.NumbeoCost != nil,
-		indicesEnabled: c.NumbeoIndices != nil,
+		indicesEnabled: c.NumbeoCityIndices != nil,
 		climateEnabled: c.AvgClimate != nil,
 	}
 }
@@ -190,8 +190,8 @@ type queryParamsCountry struct {
 
 func countryFildsToBool(c data.Country) queryParamsCountry {
 	return queryParamsCountry{
-		numbeoIndicesEnabled:  c.NumbeoIndices != nil,
-		legatumIndicesEnabled: c.LegatumIndices != nil,
+		numbeoIndicesEnabled:  c.NumbeoCountryIndices != nil,
+		legatumIndicesEnabled: c.LegatumCountryIndices != nil,
 	}
 }
 

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -12,17 +12,17 @@ import (
 )
 
 type City struct {
-	CityID        int64        `json:"city_id"`
-	City          string       `json:"city"`
-	StateCode     *string      `json:"state_code"`
-	CountryCode   string       `json:"country_code"`
-	Country       string       `json:"country,omitzero"`
-	NumbeoCost    *CostDetails `json:"numbeo_cost,omitzero"`
-	NumbeoIndices *Indices     `json:"numbeo_indices,omitzero"`
-	AvgClimate    *AvgClimate  `json:"avg_climate,omitzero"`
+	ID                int64              `json:"city_id"`
+	Name              string             `json:"city"`
+	StateCode         *string            `json:"state_code"`
+	CountryCode       string             `json:"country_code"`
+	Country           string             `json:"country,omitzero"`
+	NumbeoCost        *NumbeoCost        `json:"numbeo_cost,omitzero"`
+	NumbeoCityIndices *NumbeoCityIndices `json:"numbeo_indices,omitzero"`
+	AvgClimate        *AvgClimate        `json:"avg_climate,omitzero"`
 }
 
-type CostDetails struct {
+type NumbeoCost struct {
 	Currency   string  `json:"currency"`
 	LastUpdate string  `json:"last_update"`
 	Prices     []Price `json:"prices"`
@@ -36,7 +36,7 @@ type Price struct {
 	RangeUpper *float64 `json:"range_upper"`
 }
 
-type Indices struct {
+type NumbeoCityIndices struct {
 	CostOfLiving               *float64 `json:"cost_of_living"`
 	Rent                       *float64 `json:"rent"`
 	CostOfLivingPlusRent       *float64 `json:"cost_of_living_plus_rent"`
@@ -120,8 +120,8 @@ func (c CityModel) ListCities(countryCode string, include IncludeSet) (cities []
 	for rows.Next() {
 		var city City
 		if err := rows.Scan(
-			&city.CityID,
-			&city.City,
+			&city.ID,
+			&city.Name,
 			&city.StateCode,
 			&city.CountryCode,
 			&city.Country,
@@ -270,8 +270,8 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 		include.Has("numbeo_indices"),
 		include.Has("avg_climate"),
 	).Scan(
-		&city.CityID,
-		&city.City,
+		&city.ID,
+		&city.Name,
 		&city.StateCode,
 		&city.CountryCode,
 		&city.Country,
@@ -287,7 +287,7 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 	}
 
 	if len(costJSON) > 0 {
-		var details CostDetails
+		var details NumbeoCost
 		if err := json.Unmarshal(costJSON, &details); err != nil {
 			return nil, err
 		}
@@ -295,11 +295,11 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 	}
 
 	if len(indicesJSON) > 0 {
-		var details Indices
+		var details NumbeoCityIndices
 		if err := json.Unmarshal(indicesJSON, &details); err != nil {
 			return nil, err
 		}
-		city.NumbeoIndices = &details
+		city.NumbeoCityIndices = &details
 	}
 
 	if len(climateJSON) > 0 && string(climateJSON) != "null" {
@@ -343,8 +343,8 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 	for rows.Next() {
 		var city City
 		if err := rows.Scan(
-			&city.CityID,
-			&city.City,
+			&city.ID,
+			&city.Name,
 			&city.StateCode,
 			&city.CountryCode,
 			&city.Country,

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -19,7 +19,7 @@ func TestListCities(t *testing.T) {
 	}
 
 	assert.Equal(t, len(cities), 534)
-	assert.Equal(t, cities[0].CityID, int64(1))
+	assert.Equal(t, cities[0].ID, int64(1))
 	assert.Equal(t, cities[0].Country, "")
 }
 
@@ -45,10 +45,10 @@ func TestGetCity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, city.CityID, int64(273))
+	assert.Equal(t, city.ID, int64(273))
 	assert.Equal(t, city.Country, "Japan")
 	assert.Equal(t, city.NumbeoCost != nil, true)
-	assert.Equal(t, city.NumbeoIndices != nil, true)
+	assert.Equal(t, city.NumbeoCityIndices != nil, true)
 }
 
 func TestGetCitiesByIDs(t *testing.T) {
@@ -61,9 +61,9 @@ func TestGetCitiesByIDs(t *testing.T) {
 	}
 
 	assert.Equal(t, len(cities), 2)
-	assert.Equal(t, cities[0].CityID, int64(11))
+	assert.Equal(t, cities[0].ID, int64(11))
 	assert.Equal(t, cities[0].Country != "", true)
-	assert.Equal(t, cities[1].CityID, int64(94))
+	assert.Equal(t, cities[1].ID, int64(94))
 }
 
 func TestGetCityAvgClimateOrderedByMonth(t *testing.T) {

--- a/internal/data/countries.go
+++ b/internal/data/countries.go
@@ -11,13 +11,13 @@ import (
 )
 
 type Country struct {
-	Code           string                 `json:"country_code"`
-	Name           string                 `json:"country"`
-	NumbeoIndices  *NumbeoCountryIndicies `json:"numbeo_indices,omitempty"`
-	LegatumIndices *LegatumCountryIndices `json:"legatum_indices,omitempty"`
+	Code                  string                 `json:"country_code"`
+	Name                  string                 `json:"country"`
+	NumbeoCountryIndices  *NumbeoCountryIndices  `json:"numbeo_indices,omitempty"`
+	LegatumCountryIndices *LegatumCountryIndices `json:"legatum_indices,omitempty"`
 }
 
-type NumbeoCountryIndicies struct {
+type NumbeoCountryIndices struct {
 	CostOfLiving               *float64 `json:"cost_of_living"`
 	Rent                       *float64 `json:"rent"`
 	CostOfLivingPlusRent       *float64 `json:"cost_of_living_plus_rent"`
@@ -216,11 +216,11 @@ func (c CountryModel) GetCountry(countryCode string, include IncludeSet) (*Count
 	}
 
 	if len(numbeoJSON) > 0 {
-		var indices NumbeoCountryIndicies
+		var indices NumbeoCountryIndices
 		if err := json.Unmarshal(numbeoJSON, &indices); err != nil {
 			return nil, err
 		}
-		country.NumbeoIndices = &indices
+		country.NumbeoCountryIndices = &indices
 	}
 
 	if len(legatumJSON) > 0 && string(legatumJSON) != "null" {
@@ -228,7 +228,7 @@ func (c CountryModel) GetCountry(countryCode string, include IncludeSet) (*Count
 		if err := json.Unmarshal(legatumJSON, &indices); err != nil {
 			return nil, err
 		}
-		country.LegatumIndices = &indices
+		country.LegatumCountryIndices = &indices
 	}
 
 	return &country, nil

--- a/internal/data/countries_test.go
+++ b/internal/data/countries_test.go
@@ -31,8 +31,8 @@ func TestGetCountry(t *testing.T) {
 	}
 
 	assert.Equal(t, country.Code, "USA")
-	assert.Equal(t, country.NumbeoIndices != nil, true)
-	assert.Equal(t, country.LegatumIndices != nil, true)
+	assert.Equal(t, country.NumbeoCountryIndices != nil, true)
+	assert.Equal(t, country.LegatumCountryIndices != nil, true)
 }
 
 func TestGetCountriesByCodes(t *testing.T) {


### PR DESCRIPTION
## Summary
Brings domain model naming in line with the project schema/documentation for consistent terminology across data models, handlers, mappers, and tests.

## Changes
- aligned city/country domain naming with the documented schema
- updated related references in API layer and tests
- kept runtime behavior unchanged (naming refactor only)

## Verification
- `make test`