### PR TITLE
feat(api): add batch include support for /cities?ids and align city baseline payload

### DIFF
--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -19,7 +19,7 @@ func (app *application) listCitiesHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	include, err := parseInclude(qs, newIncludeSet("country"))
+	include, err := parseInclude(qs, newIncludeSet("country", "numbeo_cost", "numbeo_indices", "avg_climate"))
 	if err != nil {
 		app.failedValidationResponse(w, r, map[string]string{"include": err.Error()})
 		return
@@ -31,6 +31,13 @@ func (app *application) listCitiesHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if idsPresent {
+		if hasDetailedCityInclude(include) && len(ids) > 20 {
+			app.failedValidationResponse(w, r, map[string]string{
+				"ids": "ids cannot contain more than 20 unique values when detailed include blocks are requested",
+			})
+			return
+		}
+
 		cities, err := app.models.Cities.GetCitiesByIDs(ids, include)
 		if err != nil {
 			switch {
@@ -42,10 +49,22 @@ func (app *application) listCitiesHandler(w http.ResponseWriter, r *http.Request
 			return
 		}
 
-		err = app.writeJSON(w, http.StatusOK, envelope{"cities": cities}, nil)
+		resp := make([]cityResponse, 0, len(cities))
+		for _, city := range cities {
+			resp = append(resp, newCityResponse(city, include))
+		}
+
+		err = app.writeJSON(w, http.StatusOK, envelope{"cities": resp}, nil)
 		if err != nil {
 			app.serverErrorResponse(w, r, err)
 		}
+		return
+	}
+
+	if hasDetailedCityInclude(include) {
+		app.failedValidationResponse(w, r, map[string]string{
+			"include": "detailed include blocks are supported only for batch ids requests",
+		})
 		return
 	}
 
@@ -74,6 +93,10 @@ func (app *application) listCitiesHandler(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		app.serverErrorResponse(w, r, err)
 	}
+}
+
+func hasDetailedCityInclude(include data.IncludeSet) bool {
+	return include.Has("numbeo_cost") || include.Has("numbeo_indices") || include.Has("avg_climate")
 }
 
 func (app *application) showCityHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/api/cities.go
+++ b/cmd/api/cities.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/denis-k2/relohelper-go/internal/data"
@@ -31,9 +32,9 @@ func (app *application) listCitiesHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if idsPresent {
-		if hasDetailedCityInclude(include) && len(ids) > 20 {
+		if hasDetailedCityInclude(include) && len(ids) > app.config.batch.maxDetailedIDs {
 			app.failedValidationResponse(w, r, map[string]string{
-				"ids": "ids cannot contain more than 20 unique values when detailed include blocks are requested",
+				"ids": fmt.Sprintf("ids cannot contain more than %d unique values when detailed include blocks are requested", app.config.batch.maxDetailedIDs),
 			})
 			return
 		}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -40,7 +40,8 @@ type config struct {
 		enabled bool
 	}
 	batch struct {
-		maxIDs int
+		maxIDs         int
+		maxDetailedIDs int
 	}
 	smtp struct {
 		host     string
@@ -117,6 +118,7 @@ func parseFlags() (config, error) {
 	flag.IntVar(&cfg.limiter.burst, "limiter-burst", 20, "Rate limiter maximum burst")
 	flag.BoolVar(&cfg.limiter.enabled, "limiter-enabled", true, "Enable rate limiter")
 	flag.IntVar(&cfg.batch.maxIDs, "batch-max-ids", 100, "Maximum number of unique IDs in batch query parameters")
+	flag.IntVar(&cfg.batch.maxDetailedIDs, "batch-max-detailed-ids", 20, "Maximum number of unique city IDs in batch query when detailed include blocks are requested")
 
 	flag.StringVar(&cfg.smtp.host, "smtp-host", os.Getenv("RELOHELPER_SMTP_HOST"), "SMTP host")
 	flag.IntVar(&cfg.smtp.port, "smtp-port", 25, "SMTP port")

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -213,7 +213,7 @@ func TestCitiesBatchByIDsDetailedIncludeLimit(t *testing.T) {
 	var got gotResponse
 	unmarshalJSON(t, body, &got)
 	assert.DeepEqual(t, got.Error, map[string]any{
-		"ids": "ids cannot contain more than 20 unique values when detailed include blocks are requested",
+		"ids": fmt.Sprintf("ids cannot contain more than %d unique values when detailed include blocks are requested", testApp.config.batch.maxDetailedIDs),
 	})
 }
 

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -48,18 +48,21 @@ func TestCities(t *testing.T) {
 			Name:        "New York",
 			StateCode:   ptrString("US-NY"),
 			CountryCode: "USA",
+			CountryName: "United States of America",
 		},
 		{
 			ID:          94,
 			Name:        "Toronto",
 			StateCode:   nil,
 			CountryCode: "CAN",
+			CountryName: "Canada",
 		},
 		{
 			ID:          464,
 			Name:        "Moscow",
 			StateCode:   nil,
 			CountryCode: "RUS",
+			CountryName: "Russian Federation",
 		},
 	}
 	for _, city := range wantCities {
@@ -175,7 +178,43 @@ func TestCitiesBatchByIDs(t *testing.T) {
 	unmarshalJSON(t, body, &got)
 	assert.Equal(t, len(got.Cities), 2)
 	assert.Equal(t, got.Cities[0].ID, int64(11))
+	assert.Equal(t, got.Cities[0].CountryName, "United States of America")
 	assert.Equal(t, got.Cities[1].ID, int64(94))
+	assert.Equal(t, got.Cities[1].CountryName, "Canada")
+}
+
+// TestCitiesBatchByIDsWithInclude tests include behavior for "/cities?ids=...&include=...".
+func TestCitiesBatchByIDsWithInclude(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, body := ts.get(t, "/cities?ids=329,11&include=avg_climate")
+	assert.Equal(t, statusCode, http.StatusOK)
+	assert.Equal(t, header.Get("content-type"), "application/json")
+	assert.Equal(t, jsonArrayObjectHasKeyByID(body, "cities", "city_id", int64(329), "avg_climate"), true)
+	assert.Equal(t, jsonArrayObjectIsNullByID(body, "cities", "city_id", int64(329), "avg_climate"), true)
+}
+
+// TestCitiesBatchByIDsDetailedIncludeLimit tests include batch limit for "/cities?ids=...&include=...".
+func TestCitiesBatchByIDsDetailedIncludeLimit(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	rawIDs := make([]string, 0, 21)
+	for i := 1; i <= 21; i++ {
+		rawIDs = append(rawIDs, fmt.Sprintf("%d", i))
+	}
+
+	urlPath := fmt.Sprintf("/cities?ids=%s&include=numbeo_indices", strings.Join(rawIDs, ","))
+	statusCode, header, body := ts.get(t, urlPath)
+	assert.Equal(t, statusCode, http.StatusUnprocessableEntity)
+	assert.Equal(t, header.Get("content-type"), "application/json")
+
+	var got gotResponse
+	unmarshalJSON(t, body, &got)
+	assert.DeepEqual(t, got.Error, map[string]any{
+		"ids": "ids cannot contain more than 20 unique values when detailed include blocks are requested",
+	})
 }
 
 // TestCity tests the “/cities/:id” endpoint.
@@ -525,6 +564,77 @@ func jsonIsNull(body []byte, rootKey, key string) bool {
 	}
 
 	return string(v) == "null"
+}
+
+func jsonArrayObjectHasKeyByID(body []byte, rootKey, idKey string, id int64, key string) bool {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+
+	rootRaw, ok := payload[rootKey]
+	if !ok {
+		return false
+	}
+
+	var items []map[string]json.RawMessage
+	if err := json.Unmarshal(rootRaw, &items); err != nil {
+		return false
+	}
+
+	for _, item := range items {
+		idRaw, ok := item[idKey]
+		if !ok {
+			continue
+		}
+
+		var gotID int64
+		if err := json.Unmarshal(idRaw, &gotID); err != nil || gotID != id {
+			continue
+		}
+
+		_, exists := item[key]
+		return exists
+	}
+
+	return false
+}
+
+func jsonArrayObjectIsNullByID(body []byte, rootKey, idKey string, id int64, key string) bool {
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return false
+	}
+
+	rootRaw, ok := payload[rootKey]
+	if !ok {
+		return false
+	}
+
+	var items []map[string]json.RawMessage
+	if err := json.Unmarshal(rootRaw, &items); err != nil {
+		return false
+	}
+
+	for _, item := range items {
+		idRaw, ok := item[idKey]
+		if !ok {
+			continue
+		}
+
+		var gotID int64
+		if err := json.Unmarshal(idRaw, &gotID); err != nil || gotID != id {
+			continue
+		}
+
+		raw, exists := item[key]
+		if !exists {
+			return false
+		}
+		return string(raw) == "null"
+	}
+
+	return false
 }
 
 // TestCountries tests the “/countries" endpoint.

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -97,7 +97,7 @@ type CityModel struct {
 func (c CityModel) ListCities(countryCode string, include IncludeSet) (cities []*City, retErr error) {
 	query := `
 		SELECT c.city_id, c.city, c.state_code, c.country_code,
-		       CASE WHEN $2 THEN ctr.country ELSE '' END AS country
+		       ctr.country AS country
 		FROM city c
 		LEFT JOIN country ctr ON ctr.country_code = c.country_code
 		WHERE (LOWER(c.country_code) = LOWER($1) OR $1 = '')
@@ -106,7 +106,7 @@ func (c CityModel) ListCities(countryCode string, include IncludeSet) (cities []
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	rows, err := c.DB.QueryContext(ctx, query, countryCode, include.Has("country"))
+	rows, err := c.DB.QueryContext(ctx, query, countryCode)
 	if err != nil {
 		return nil, err
 	}
@@ -152,9 +152,9 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 			c.city,
 			c.state_code,
 			c.country_code,
-			CASE WHEN $2 THEN ctr.country ELSE '' END AS country,
+			ctr.country AS country,
 			CASE
-				WHEN $3 THEN (
+				WHEN $2 THEN (
 					SELECT CASE
 						WHEN COUNT(*) = 0 THEN NULL
 						ELSE jsonb_build_object(
@@ -180,7 +180,7 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 				ELSE NULL
 			END AS numbeo_cost,
 			CASE
-				WHEN $4 THEN (
+				WHEN $3 THEN (
 					SELECT row_to_json(n)
 					FROM (
 						SELECT
@@ -204,7 +204,7 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 				ELSE NULL
 			END AS numbeo_indices,
 			CASE
-				WHEN $5 THEN (
+				WHEN $4 THEN (
 					WITH climate_rows AS (
 						SELECT *
 						FROM avg_climate ac
@@ -265,7 +265,6 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 		ctx,
 		query,
 		id,
-		include.Has("country"),
 		include.Has("numbeo_cost"),
 		include.Has("numbeo_indices"),
 		include.Has("avg_climate"),
@@ -320,7 +319,7 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 
 	query := `
 		SELECT c.city_id, c.city, c.state_code, c.country_code,
-		       CASE WHEN $2 THEN ctr.country ELSE '' END AS country
+		       ctr.country AS country
 		FROM city c
 		LEFT JOIN country ctr ON ctr.country_code = c.country_code
 		WHERE c.city_id = ANY($1)
@@ -329,7 +328,7 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	rows, err := c.DB.QueryContext(ctx, query, pq.Array(ids), include.Has("country"))
+	rows, err := c.DB.QueryContext(ctx, query, pq.Array(ids))
 	if err != nil {
 		return nil, err
 	}
@@ -340,6 +339,7 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 	}()
 
 	cities = []*City{}
+	cityByID := make(map[int64]*City, len(ids))
 	for rows.Next() {
 		var city City
 		if err := rows.Scan(
@@ -351,7 +351,9 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 		); err != nil {
 			return nil, err
 		}
-		cities = append(cities, &city)
+		cityPtr := &city
+		cities = append(cities, cityPtr)
+		cityByID[city.ID] = cityPtr
 	}
 
 	if err = rows.Err(); err != nil {
@@ -361,7 +363,250 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 		return nil, ErrRecordNotFound
 	}
 
+	if include.Has("numbeo_cost") {
+		err = c.attachNumbeoCostByCityIDs(ctx, ids, cityByID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if include.Has("numbeo_indices") {
+		err = c.attachNumbeoCityIndicesByCityIDs(ctx, ids, cityByID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if include.Has("avg_climate") {
+		err = c.attachAvgClimateByCityIDs(ctx, ids, cityByID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return cities, nil
+}
+
+func (c CityModel) attachNumbeoCostByCityIDs(ctx context.Context, ids []int64, cityByID map[int64]*City) (retErr error) {
+	query := `
+		SELECT
+			ns.city_id,
+			jsonb_build_object(
+				'currency', MAX(ns.currency),
+				'last_update', to_char(MAX(ns.updated_date), 'YYYY-MM-DD'),
+				'prices', jsonb_agg(
+					jsonb_build_object(
+						'category', nc.category,
+						'param', np.param,
+						'cost', ns.cost,
+						'range_lower', lower(ns.range),
+						'range_upper', upper(ns.range)
+					)
+					ORDER BY nc.category, np.param
+				)
+			) AS numbeo_cost
+		FROM numbeo_stat ns
+		JOIN numbeo_param np ON np.param_id = ns.param_id
+		JOIN numbeo_category nc ON nc.category_id = np.category_id
+		WHERE ns.city_id = ANY($1)
+		GROUP BY ns.city_id;`
+
+	rows, err := c.DB.QueryContext(ctx, query, pq.Array(ids))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+
+	for rows.Next() {
+		var (
+			cityID  int64
+			rawJSON []byte
+		)
+
+		if err := rows.Scan(&cityID, &rawJSON); err != nil {
+			return err
+		}
+		if len(rawJSON) == 0 || string(rawJSON) == "null" {
+			continue
+		}
+
+		var details NumbeoCost
+		if err := json.Unmarshal(rawJSON, &details); err != nil {
+			return err
+		}
+
+		city, ok := cityByID[cityID]
+		if !ok {
+			continue
+		}
+		city.NumbeoCost = &details
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c CityModel) attachNumbeoCityIndicesByCityIDs(ctx context.Context, ids []int64, cityByID map[int64]*City) (retErr error) {
+	query := `
+		SELECT
+			nic.city_id,
+			row_to_json(n) AS numbeo_indices
+		FROM numbeo_index_by_city nic
+		CROSS JOIN LATERAL (
+			SELECT
+				nic.cost_of_living,
+				nic.rent,
+				nic.cost_of_living_plus_rent,
+				nic.groceries,
+				nic.local_purchasing_power,
+				nic.quality_of_life,
+				nic.property_price_to_income_ratio,
+				nic.traffic_commute_time,
+				nic.climate,
+				nic.safety,
+				nic.health_care,
+				nic.pollution,
+				to_char(nic.sys_updated_date, 'YYYY-MM-DD') AS last_update
+		) AS n
+		WHERE nic.city_id = ANY($1);`
+
+	rows, err := c.DB.QueryContext(ctx, query, pq.Array(ids))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+
+	for rows.Next() {
+		var (
+			cityID  int64
+			rawJSON []byte
+		)
+
+		if err := rows.Scan(&cityID, &rawJSON); err != nil {
+			return err
+		}
+		if len(rawJSON) == 0 || string(rawJSON) == "null" {
+			continue
+		}
+
+		var details NumbeoCityIndices
+		if err := json.Unmarshal(rawJSON, &details); err != nil {
+			return err
+		}
+
+		city, ok := cityByID[cityID]
+		if !ok {
+			continue
+		}
+		city.NumbeoCityIndices = &details
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c CityModel) attachAvgClimateByCityIDs(ctx context.Context, ids []int64, cityByID map[int64]*City) (retErr error) {
+	query := `
+		WITH climate_rows AS (
+			SELECT *
+			FROM avg_climate ac
+			WHERE ac.city_id = ANY($1)
+		),
+		climate_stats AS (
+			SELECT
+				city_id,
+				COUNT(*) AS row_count,
+				COUNT(DISTINCT month) AS unique_month_count,
+				MIN(month) AS min_month,
+				MAX(month) AS max_month
+			FROM climate_rows
+			GROUP BY city_id
+		),
+		climate_data AS (
+			SELECT
+				cr.city_id,
+				m.metric_key,
+				jsonb_agg(m.metric_value ORDER BY cr.month) AS month_values
+			FROM climate_rows cr
+			CROSS JOIN LATERAL jsonb_each(
+				to_jsonb(cr)
+					- 'city_id'
+					- 'month'
+					- 'sys_updated_date'
+					- 'sys_updeted_by'
+			) AS m(metric_key, metric_value)
+			GROUP BY cr.city_id, m.metric_key
+		)
+		SELECT
+			s.city_id,
+			CASE
+				WHEN s.row_count = 12
+					AND s.unique_month_count = 12
+					AND s.min_month = 1
+					AND s.max_month = 12
+				THEN (
+					SELECT jsonb_object_agg(cd.metric_key, cd.month_values)
+					FROM climate_data cd
+					WHERE cd.city_id = s.city_id
+				)
+				ELSE jsonb_build_object('__invalid_structure__', true)
+			END AS avg_climate
+		FROM climate_stats s;`
+
+	rows, err := c.DB.QueryContext(ctx, query, pq.Array(ids))
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := rows.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+
+	for rows.Next() {
+		var (
+			cityID  int64
+			rawJSON []byte
+		)
+
+		if err := rows.Scan(&cityID, &rawJSON); err != nil {
+			return err
+		}
+		if len(rawJSON) == 0 || string(rawJSON) == "null" {
+			continue
+		}
+
+		avgClimate, err := decodeAvgClimateSeries(cityID, rawJSON)
+		if err != nil {
+			return err
+		}
+
+		city, ok := cityByID[cityID]
+		if !ok {
+			continue
+		}
+		city.AvgClimate = avgClimate
+	}
+
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func decodeAvgClimateSeries(cityID int64, rawJSON []byte) (*AvgClimate, error) {

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -20,7 +20,7 @@ func TestListCities(t *testing.T) {
 
 	assert.Equal(t, len(cities), 534)
 	assert.Equal(t, cities[0].ID, int64(1))
-	assert.Equal(t, cities[0].CountryName, "")
+	assert.Equal(t, cities[0].CountryName != "", true)
 }
 
 func TestListCitiesWithCountryInclude(t *testing.T) {


### PR DESCRIPTION
## Summary
Implements batch include support for `/cities?ids=...` with bounded `1+K` loading, unifies baseline `City` shape across list/detail/batch by always returning `country`, and moves the detailed batch limit to config.

## Changes
- Added batch include support for `/cities?ids=...`:
1. `include=numbeo_cost`
2. `include=numbeo_indices`
3. `include=avg_climate`
- Implemented DAL loading in `CityModel.GetCitiesByIDs(ids, include)` with max query fan-out `1+3`:
1. base cities query
2. one query for `numbeo_cost` (all ids)
3. one query for `numbeo_indices` (all ids)
4. one query for `avg_climate` (all ids)
- Added map-based merge by `city_id` to attach include blocks to base city rows.
- Include semantics preserved in batch response:
1. include requested + no data => field present as `null`
2. include not requested => field omitted
- Unified baseline city payload:
1. `country` is now always selected via `LEFT JOIN country`
2. applies to `ListCities`, `GetCitiesByIDs` (base), and `GetCity`
3. removed conditional `CASE WHEN include_country` logic
- Removed hardcoded detailed batch limit:
1. added config flag `-batch-max-detailed-ids` (default `20`)
2. validation now uses `cfg.batch.maxDetailedIDs`
3. error message uses configured value
- Updated tests for:
1. batch include field presence/null behavior
2. detailed include limit validation
3. baseline `country` expectations in list/batch

## Validation
- `make test`