### PR TITLE
chore(auth): add runtime toggle to disable authentication locally

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -39,6 +39,9 @@ type config struct {
 		burst   int
 		enabled bool
 	}
+	auth struct {
+		enabled bool
+	}
 	batch struct {
 		maxIDs         int
 		maxDetailedIDs int
@@ -117,6 +120,7 @@ func parseFlags() (config, error) {
 	flag.Float64Var(&cfg.limiter.rps, "limiter-rps", 10, "Rate limiter maximum requests per second")
 	flag.IntVar(&cfg.limiter.burst, "limiter-burst", 20, "Rate limiter maximum burst")
 	flag.BoolVar(&cfg.limiter.enabled, "limiter-enabled", true, "Enable rate limiter")
+	flag.BoolVar(&cfg.auth.enabled, "auth-enabled", true, "Enable authentication and activated-user checks")
 	flag.IntVar(&cfg.batch.maxIDs, "batch-max-ids", 100, "Maximum number of unique IDs in batch query parameters")
 	flag.IntVar(&cfg.batch.maxDetailedIDs, "batch-max-detailed-ids", 20, "Maximum number of unique city IDs in batch query when detailed include blocks are requested")
 

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -12,7 +12,9 @@ func (app *application) routes() http.Handler {
 	router.Use(app.recoverPanic)
 	router.Use(app.enableCORS)
 	router.Use(app.rateLimit)
-	router.Use(app.authenticate)
+	if app.config.auth.enabled {
+		router.Use(app.authenticate)
+	}
 
 	router.NotFound(app.notFoundResponse)
 	router.MethodNotAllowed(app.methodNotAllowedResponse)
@@ -20,9 +22,14 @@ func (app *application) routes() http.Handler {
 	router.Get("/healthcheck", app.healthcheckHandler)
 
 	router.Get("/cities", app.listCitiesHandler)
-	router.With(app.requireActivatedUser).Get("/cities/{id}", app.showCityHandler)
 	router.Get("/countries", app.listCountriesHandler)
-	router.With(app.requireActivatedUser).Get("/countries/{alpha3}", app.showCountryHandler)
+	if app.config.auth.enabled {
+		router.With(app.requireActivatedUser).Get("/cities/{id}", app.showCityHandler)
+		router.With(app.requireActivatedUser).Get("/countries/{alpha3}", app.showCountryHandler)
+	} else {
+		router.Get("/cities/{id}", app.showCityHandler)
+		router.Get("/countries/{alpha3}", app.showCountryHandler)
+	}
 
 	router.Post("/users", app.registerUserHandler)
 	router.Put("/users/activated", app.activateUserHandler)


### PR DESCRIPTION
## Summary
Adds a runtime auth toggle so authentication can be disabled locally without editing routes by hand. This simplifies development and debugging while keeping the default production/test behavior unchanged.

## Changes
- Added config flag `-auth-enabled` with default `true`.
- Updated router setup to apply auth middleware only when `auth-enabled` is on:
1. global `authenticate`
2. route-level `requireActivatedUser` for city/country detail endpoints
- When `-auth-enabled=false`, detail endpoints stay available without auth checks.
- Default behavior remains unchanged, so existing tests and normal app behavior are preserved.

## Validation
- `make test`