### PR TITLE
refactor(data): align API queries and tests with 2026 database schema

### DIFF
--- a/cmd/api/response_mappers.go
+++ b/cmd/api/response_mappers.go
@@ -3,7 +3,7 @@ package main
 import "github.com/denis-k2/relohelper-go/internal/data"
 
 type cityResponse struct {
-	CityID        int64   `json:"city_id"`
+	CityID        int64   `json:"geoname_id"`
 	City          string  `json:"city"`
 	StateCode     *string `json:"state_code"`
 	CountryCode   string  `json:"country_code"`

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -40,25 +40,25 @@ func TestCities(t *testing.T) {
 
 	var got gotResponse
 	unmarshalJSON(t, body, &got)
-	assert.Equal(t, len(got.Cities), 534)
+	assert.Equal(t, len(got.Cities) > 0, true)
 
 	wantCities := []data.City{
 		{
-			ID:          11,
+			ID:          5128581,
 			Name:        "New York",
 			StateCode:   ptrString("US-NY"),
 			CountryCode: "USA",
 			CountryName: "United States of America",
 		},
 		{
-			ID:          94,
+			ID:          6167865,
 			Name:        "Toronto",
 			StateCode:   nil,
 			CountryCode: "CAN",
 			CountryName: "Canada",
 		},
 		{
-			ID:          464,
+			ID:          524901,
 			Name:        "Moscow",
 			StateCode:   nil,
 			CountryCode: "RUS",
@@ -66,8 +66,21 @@ func TestCities(t *testing.T) {
 		},
 	}
 	for _, city := range wantCities {
-		assert.DeepEqual(t, got.Cities[city.ID-1], city)
+		assert.DeepEqual(t, findCityByID(t, got.Cities, city.ID), city)
 	}
+}
+
+func findCityByID(t *testing.T, cities []data.City, id int64) data.City {
+	t.Helper()
+
+	for _, city := range cities {
+		if city.ID == id {
+			return city
+		}
+	}
+
+	t.Fatalf("city with id=%d not found in response", id)
+	return data.City{}
 }
 
 // TestCities tests the “/cities” endpoint with query parameter.
@@ -78,25 +91,21 @@ func TestCitiesByCountry(t *testing.T) {
 	tests := []struct {
 		name        string
 		countryCode string
-		citiesCount int
 		statusCode  int
 	}{
 		{
 			name:        "Valid uppercase code (USA)",
 			countryCode: "USA",
-			citiesCount: 58,
 			statusCode:  http.StatusOK,
 		},
 		{
 			name:        "Valid mixed case code (cAn)",
 			countryCode: "cAn",
-			citiesCount: 29,
 			statusCode:  http.StatusOK,
 		},
 		{
 			name:        "Valid lowercase code (rus)",
 			countryCode: "rus",
-			citiesCount: 8,
 			statusCode:  http.StatusOK,
 		},
 		{
@@ -136,7 +145,7 @@ func TestCitiesByCountry(t *testing.T) {
 		},
 		{
 			name:        "SQL injection attempt",
-			countryCode: url.QueryEscape("usa'; DROP TABLE city;"),
+			countryCode: url.QueryEscape("usa'; DROP TABLE cities;"),
 			statusCode:  http.StatusUnprocessableEntity,
 		},
 	}
@@ -150,9 +159,22 @@ func TestCitiesByCountry(t *testing.T) {
 			var got gotResponse
 			unmarshalJSON(t, body, &got)
 			assert.Equal(t, header.Get("content-type"), "application/json")
-			assert.Equal(t, len(got.Cities), tt.citiesCount)
 
 			switch tt.statusCode {
+			case http.StatusOK:
+				var expectedCount int
+				err := testDB.QueryRow(`
+					SELECT COUNT(*)
+					FROM cities
+					WHERE LOWER(country_code) = LOWER($1);`, tt.countryCode).Scan(&expectedCount)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				assert.Equal(t, len(got.Cities), expectedCount)
+				for _, city := range got.Cities {
+					assert.Equal(t, strings.EqualFold(city.CountryCode, tt.countryCode), true)
+				}
 			case http.StatusUnprocessableEntity:
 				wantError := map[string]any{
 					"country_code": "must be exactly three English letters",
@@ -170,16 +192,16 @@ func TestCitiesBatchByIDs(t *testing.T) {
 	ts := newTestServer(testApp.routes())
 	defer ts.Close()
 
-	statusCode, header, body := ts.get(t, "/cities?ids=11,94,11")
+	statusCode, header, body := ts.get(t, "/cities?ids=5128581,6167865,5128581")
 	assert.Equal(t, statusCode, http.StatusOK)
 	assert.Equal(t, header.Get("content-type"), "application/json")
 
 	var got gotResponse
 	unmarshalJSON(t, body, &got)
 	assert.Equal(t, len(got.Cities), 2)
-	assert.Equal(t, got.Cities[0].ID, int64(11))
+	assert.Equal(t, got.Cities[0].ID, int64(5128581))
 	assert.Equal(t, got.Cities[0].CountryName, "United States of America")
-	assert.Equal(t, got.Cities[1].ID, int64(94))
+	assert.Equal(t, got.Cities[1].ID, int64(6167865))
 	assert.Equal(t, got.Cities[1].CountryName, "Canada")
 }
 
@@ -188,11 +210,11 @@ func TestCitiesBatchByIDsWithInclude(t *testing.T) {
 	ts := newTestServer(testApp.routes())
 	defer ts.Close()
 
-	statusCode, header, body := ts.get(t, "/cities?ids=329,11&include=avg_climate")
+	statusCode, header, body := ts.get(t, "/cities?ids=3069011,5128581&include=avg_climate")
 	assert.Equal(t, statusCode, http.StatusOK)
 	assert.Equal(t, header.Get("content-type"), "application/json")
-	assert.Equal(t, jsonArrayObjectHasKeyByID(body, "cities", "city_id", int64(329), "avg_climate"), true)
-	assert.Equal(t, jsonArrayObjectIsNullByID(body, "cities", "city_id", int64(329), "avg_climate"), true)
+	assert.Equal(t, jsonArrayObjectHasKeyByID(body, "cities", "geoname_id", int64(3069011), "avg_climate"), true)
+	assert.Equal(t, jsonArrayObjectIsNullByID(body, "cities", "geoname_id", int64(3069011), "avg_climate"), true)
 }
 
 // TestCitiesBatchByIDsDetailedIncludeLimit tests include batch limit for "/cities?ids=...&include=...".
@@ -230,10 +252,10 @@ func TestCityID(t *testing.T) {
 	}{
 		{
 			name:       "Valid ID (No query params)",
-			urlPath:    "/cities/15",
+			urlPath:    "/cities/5809844",
 			statusCode: http.StatusOK,
 			city: data.City{
-				ID:          15,
+				ID:          5809844,
 				Name:        "Seattle",
 				StateCode:   ptrString("US-WA"),
 				CountryCode: "USA",
@@ -242,10 +264,10 @@ func TestCityID(t *testing.T) {
 		},
 		{
 			name:       "Valid ID with include query",
-			urlPath:    "/cities/273?include=country",
+			urlPath:    "/cities/1850147?include=country",
 			statusCode: http.StatusOK,
 			city: data.City{
-				ID:          273,
+				ID:          1850147,
 				Name:        "Tokyo",
 				StateCode:   nil,
 				CountryCode: "JPN",
@@ -309,7 +331,7 @@ func TestCityIDandQuery(t *testing.T) {
 	}{
 		{
 			name:       "One param enabled",
-			urlPath:    "/cities/12?include=numbeo_cost",
+			urlPath:    "/cities/5378538?include=numbeo_cost",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    true,
@@ -319,7 +341,7 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 		{
 			name:       "Two params enabled",
-			urlPath:    "/cities/123?include=numbeo_cost,numbeo_indices",
+			urlPath:    "/cities/2562305?include=numbeo_cost,numbeo_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    true,
@@ -329,7 +351,7 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 		{
 			name:       "All params enabled",
-			urlPath:    "/cities/456?include=numbeo_cost,numbeo_indices,avg_climate",
+			urlPath:    "/cities/2542997?include=numbeo_cost,numbeo_indices,avg_climate",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    true,
@@ -339,7 +361,7 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 		{
 			name:       "Include country only",
-			urlPath:    "/cities/321?include=country",
+			urlPath:    "/cities/3871336?include=country",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    false,
@@ -349,12 +371,12 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 		{
 			name:       "Unknown params (mixed cases)",
-			urlPath:    "/cities/123?NUMBEO_COST=1&Numbeo_Indices=true&InvalidParam=TRUE",
+			urlPath:    "/cities/2562305?NUMBEO_COST=1&Numbeo_Indices=true&InvalidParam=TRUE",
 			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
 			name:       "Duplicate includes",
-			urlPath:    "/cities/234?include=numbeo_cost,numbeo_cost,avg_climate",
+			urlPath:    "/cities/1850147?include=numbeo_cost,numbeo_cost,avg_climate",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCity{
 				costEnabled:    true,
@@ -364,12 +386,12 @@ func TestCityIDandQuery(t *testing.T) {
 		},
 		{
 			name:       "Unprocessable include value (123)",
-			urlPath:    "/cities/100?include=123",
+			urlPath:    "/cities/1850147?include=123",
 			statusCode: http.StatusUnprocessableEntity,
 		},
 		{
 			name:       "Unprocessable include value (abc)",
-			urlPath:    "/cities/100?include=abc",
+			urlPath:    "/cities/1850147?include=abc",
 			statusCode: http.StatusUnprocessableEntity,
 		},
 	}
@@ -409,29 +431,29 @@ func TestCityIncludeFieldPresence(t *testing.T) {
 	ts := newTestServerWithMockUser(testApp.routes())
 	defer ts.Close()
 
-	findCityIDWithoutData := func(t *testing.T, table string, idColumn string) (int64, bool) {
+	findGeonameIDWithoutData := func(t *testing.T, table string, idColumn string) (int64, bool) {
 		t.Helper()
 
 		query := fmt.Sprintf(`
-			SELECT c.city_id
-			FROM city c
-			LEFT JOIN %s x ON x.%s = c.city_id
+			SELECT c.geoname_id
+			FROM cities c
+			LEFT JOIN %s x ON x.%s = c.geoname_id
 			WHERE x.%s IS NULL
 			LIMIT 1;`, table, idColumn, idColumn)
 
-		var cityID int64
-		if err := testDB.QueryRow(query).Scan(&cityID); err != nil {
+		var geonameID int64
+		if err := testDB.QueryRow(query).Scan(&geonameID); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return 0, false
 			}
 			t.Fatalf("failed to find city without data in %s: %v", table, err)
 		}
 
-		return cityID, true
+		return geonameID, true
 	}
 
 	t.Run("avg_climate requested and absent => explicit null", func(t *testing.T) {
-		statusCode, _, body := ts.sendRequest(t, "GET", "/cities/329?include=avg_climate,numbeo_indices", mocks.Headers, nil)
+		statusCode, _, body := ts.sendRequest(t, "GET", "/cities/3069011?include=avg_climate,numbeo_indices", mocks.Headers, nil)
 		assert.Equal(t, statusCode, http.StatusOK)
 		assert.Equal(t, jsonHasKey(body, "city", "avg_climate"), true)
 		assert.Equal(t, jsonIsNull(body, "city", "avg_climate"), true)
@@ -440,28 +462,28 @@ func TestCityIncludeFieldPresence(t *testing.T) {
 	})
 
 	t.Run("avg_climate not requested => field omitted", func(t *testing.T) {
-		statusCode, _, body := ts.sendRequest(t, "GET", "/cities/329", mocks.Headers, nil)
+		statusCode, _, body := ts.sendRequest(t, "GET", "/cities/3069011", mocks.Headers, nil)
 		assert.Equal(t, statusCode, http.StatusOK)
 		assert.Equal(t, jsonHasKey(body, "city", "avg_climate"), false)
 	})
 
 	t.Run("numbeo_cost requested and absent => explicit null", func(t *testing.T) {
-		cityID, ok := findCityIDWithoutData(t, "numbeo_stat", "city_id")
+		geonameID, ok := findGeonameIDWithoutData(t, "numbeo_city_costs", "geoname_id")
 		if !ok {
-			t.Skip("no city without numbeo_stat in test dataset")
+			t.Skip("no city without numbeo_city_costs in test dataset")
 		}
-		statusCode, _, body := ts.sendRequest(t, "GET", fmt.Sprintf("/cities/%d?include=numbeo_cost", cityID), mocks.Headers, nil)
+		statusCode, _, body := ts.sendRequest(t, "GET", fmt.Sprintf("/cities/%d?include=numbeo_cost", geonameID), mocks.Headers, nil)
 		assert.Equal(t, statusCode, http.StatusOK)
 		assert.Equal(t, jsonHasKey(body, "city", "numbeo_cost"), true)
 		assert.Equal(t, jsonIsNull(body, "city", "numbeo_cost"), true)
 	})
 
 	t.Run("numbeo_indices requested and absent => explicit null", func(t *testing.T) {
-		cityID, ok := findCityIDWithoutData(t, "numbeo_index_by_city", "city_id")
+		geonameID, ok := findGeonameIDWithoutData(t, "numbeo_city_indices", "geoname_id")
 		if !ok {
-			t.Skip("no city without numbeo_index_by_city in test dataset")
+			t.Skip("no city without numbeo_city_indices in test dataset")
 		}
-		statusCode, _, body := ts.sendRequest(t, "GET", fmt.Sprintf("/cities/%d?include=numbeo_indices", cityID), mocks.Headers, nil)
+		statusCode, _, body := ts.sendRequest(t, "GET", fmt.Sprintf("/cities/%d?include=numbeo_indices", geonameID), mocks.Headers, nil)
 		assert.Equal(t, statusCode, http.StatusOK)
 		assert.Equal(t, jsonHasKey(body, "city", "numbeo_indices"), true)
 		assert.Equal(t, jsonIsNull(body, "city", "numbeo_indices"), true)
@@ -478,7 +500,7 @@ func TestCountryIncludeFieldPresence(t *testing.T) {
 
 		query := fmt.Sprintf(`
 			SELECT ctr.country_code
-			FROM country ctr
+			FROM countries ctr
 			LEFT JOIN %s x ON x.%s = ctr.country_code
 			WHERE x.%s IS NULL
 			LIMIT 1;`, table, codeColumn, codeColumn)
@@ -494,8 +516,34 @@ func TestCountryIncludeFieldPresence(t *testing.T) {
 		return countryCode, true
 	}
 
+	findCountryCodeWithoutNumbeoWithLegatum := func(t *testing.T) (string, bool) {
+		t.Helper()
+
+		query := `
+			SELECT ctr.country_code
+			FROM countries ctr
+			LEFT JOIN numbeo_country_indices ni ON ni.country_code = ctr.country_code
+			JOIN legatum_country_indices li ON li.country_code = ctr.country_code
+			WHERE ni.country_code IS NULL
+			LIMIT 1;`
+
+		var countryCode string
+		if err := testDB.QueryRow(query).Scan(&countryCode); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return "", false
+			}
+			t.Fatalf("failed to find country without numbeo and with legatum: %v", err)
+		}
+
+		return countryCode, true
+	}
+
 	t.Run("numbeo_indices requested and absent => explicit null", func(t *testing.T) {
-		statusCode, _, body := ts.sendRequest(t, "GET", "/countries/afg?include=numbeo_indices,legatum_indices", mocks.Headers, nil)
+		countryCode, ok := findCountryCodeWithoutNumbeoWithLegatum(t)
+		if !ok {
+			t.Skip("no country without numbeo and with legatum in test dataset")
+		}
+		statusCode, _, body := ts.sendRequest(t, "GET", fmt.Sprintf("/countries/%s?include=numbeo_indices,legatum_indices", countryCode), mocks.Headers, nil)
 		assert.Equal(t, statusCode, http.StatusOK)
 		assert.Equal(t, jsonHasKey(body, "country", "numbeo_indices"), true)
 		assert.Equal(t, jsonIsNull(body, "country", "numbeo_indices"), true)
@@ -504,16 +552,16 @@ func TestCountryIncludeFieldPresence(t *testing.T) {
 	})
 
 	t.Run("include not requested => fields omitted", func(t *testing.T) {
-		statusCode, _, body := ts.sendRequest(t, "GET", "/countries/afg", mocks.Headers, nil)
+		statusCode, _, body := ts.sendRequest(t, "GET", "/countries/usa", mocks.Headers, nil)
 		assert.Equal(t, statusCode, http.StatusOK)
 		assert.Equal(t, jsonHasKey(body, "country", "numbeo_indices"), false)
 		assert.Equal(t, jsonHasKey(body, "country", "legatum_indices"), false)
 	})
 
 	t.Run("legatum_indices requested and absent => explicit null", func(t *testing.T) {
-		countryCode, ok := findCountryCodeWithoutData(t, "legatum_index", "country_code")
+		countryCode, ok := findCountryCodeWithoutData(t, "legatum_country_indices", "country_code")
 		if !ok {
-			t.Skip("no country without legatum_index in test dataset")
+			t.Skip("no country without legatum_country_indices in test dataset")
 		}
 		statusCode, _, body := ts.sendRequest(t, "GET", fmt.Sprintf("/countries/%s?include=legatum_indices", countryCode), mocks.Headers, nil)
 		assert.Equal(t, statusCode, http.StatusOK)
@@ -849,7 +897,7 @@ func TestCountry(t *testing.T) {
 		},
 		{
 			name:       "SQL injection attempt",
-			urlPath:    "/countries/" + url.QueryEscape("usa'; DROP TABLE country;"),
+			urlPath:    "/countries/" + url.QueryEscape("usa'; DROP TABLE countries;"),
 			statusCode: http.StatusUnprocessableEntity,
 		},
 	}
@@ -881,6 +929,28 @@ func TestCountry(t *testing.T) {
 func TestCountryandQuery(t *testing.T) {
 	ts := newTestServerWithMockUser(testApp.routes())
 	defer ts.Close()
+
+	findCountryCodeWithoutNumbeoWithLegatum := func(t *testing.T) (string, bool) {
+		t.Helper()
+
+		query := `
+			SELECT ctr.country_code
+			FROM countries ctr
+			LEFT JOIN numbeo_country_indices ni ON ni.country_code = ctr.country_code
+			JOIN legatum_country_indices li ON li.country_code = ctr.country_code
+			WHERE ni.country_code IS NULL
+			LIMIT 1;`
+
+		var countryCode string
+		if err := testDB.QueryRow(query).Scan(&countryCode); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return "", false
+			}
+			t.Fatalf("failed to find country without numbeo and with legatum: %v", err)
+		}
+
+		return countryCode, true
+	}
 
 	tests := []struct {
 		name        string
@@ -917,7 +987,6 @@ func TestCountryandQuery(t *testing.T) {
 		},
 		{
 			name:       "Enable both params with missing Numbeo data",
-			urlPath:    "/countries/afg?include=numbeo_indices,legatum_indices",
 			statusCode: http.StatusOK,
 			queryParams: queryParamsCountry{
 				numbeoIndicesEnabled:  false,
@@ -970,7 +1039,16 @@ func TestCountryandQuery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			statusCode, header, body := ts.sendRequest(t, "GET", tt.urlPath, mocks.Headers, nil)
+			urlPath := tt.urlPath
+			if tt.name == "Enable both params with missing Numbeo data" {
+				countryCode, ok := findCountryCodeWithoutNumbeoWithLegatum(t)
+				if !ok {
+					t.Skip("no country without numbeo and with legatum in test dataset")
+				}
+				urlPath = fmt.Sprintf("/countries/%s?include=numbeo_indices,legatum_indices", strings.ToLower(countryCode))
+			}
+
+			statusCode, header, body := ts.sendRequest(t, "GET", urlPath, mocks.Headers, nil)
 			assert.Equal(t, statusCode, tt.statusCode)
 			assert.Equal(t, header.Get("content-type"), "application/json")
 
@@ -1012,7 +1090,7 @@ func TestUnknownQueryParams(t *testing.T) {
 	}{
 		{name: "healthcheck", method: http.MethodGet, urlPath: "/healthcheck?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
 		{name: "cities list", method: http.MethodGet, urlPath: "/cities?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
-		{name: "cities detail", method: http.MethodGet, urlPath: "/cities/15?foo=bar", headers: mocks.Headers, statusCode: http.StatusUnprocessableEntity},
+		{name: "cities detail", method: http.MethodGet, urlPath: "/cities/5809844?foo=bar", headers: mocks.Headers, statusCode: http.StatusUnprocessableEntity},
 		{name: "countries list", method: http.MethodGet, urlPath: "/countries?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
 		{name: "countries detail", method: http.MethodGet, urlPath: "/countries/AUS?foo=bar", headers: mocks.Headers, statusCode: http.StatusUnprocessableEntity},
 		{name: "register user", method: http.MethodPost, urlPath: "/users?foo=bar", headers: nil, statusCode: http.StatusUnprocessableEntity},
@@ -1405,26 +1483,26 @@ func TestAuthorizationUser(t *testing.T) {
 		{
 			name:       "Valid authentication header",
 			header:     http.Header{"Authorization": []string{"Bearer " + authToken}},
-			urlPath:    "/cities/123",
+			urlPath:    "/cities/2562305",
 			statusCode: http.StatusOK,
 		},
 		{
 			name:         "Authentication with invalid token",
 			header:       http.Header{"Authorization": []string{"Bearer " + "XXXXXXXXXXXXXXX"}},
-			urlPath:      "/cities/123",
+			urlPath:      "/cities/2562305",
 			statusCode:   http.StatusUnauthorized,
 			errorMessage: "invalid or missing authentication token",
 		},
 		{
 			name:         "Malformed authorization header",
 			header:       http.Header{"Authorization": []string{"INVALID"}},
-			urlPath:      "/cities/123",
+			urlPath:      "/cities/2562305",
 			statusCode:   http.StatusUnauthorized,
 			errorMessage: "invalid or missing authentication token",
 		},
 		{
 			name:         "Missing required authorization header",
-			urlPath:      "/cities/123",
+			urlPath:      "/cities/2562305",
 			statusCode:   http.StatusUnauthorized,
 			errorMessage: "you must be authenticated to access this resource",
 		},

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -12,7 +12,7 @@ import (
 )
 
 type City struct {
-	ID                int64              `json:"city_id"`
+	ID                int64              `json:"geoname_id"`
 	Name              string             `json:"city"`
 	StateCode         *string            `json:"state_code"`
 	CountryCode       string             `json:"country_code"`
@@ -96,12 +96,12 @@ type CityModel struct {
 
 func (c CityModel) ListCities(countryCode string, include IncludeSet) (cities []*City, retErr error) {
 	query := `
-		SELECT c.city_id, c.city, c.state_code, c.country_code,
+		SELECT c.geoname_id, c.city, c.state_code, c.country_code,
 		       ctr.country AS country
-		FROM city c
-		LEFT JOIN country ctr ON ctr.country_code = c.country_code
+		FROM cities c
+		LEFT JOIN countries ctr ON ctr.country_code = c.country_code
 		WHERE (LOWER(c.country_code) = LOWER($1) OR $1 = '')
-		ORDER BY c.city_id;`
+		ORDER BY c.geoname_id;`
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -148,7 +148,7 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 
 	query := `
 		SELECT
-			c.city_id,
+			c.geoname_id,
 			c.city,
 			c.state_code,
 			c.country_code,
@@ -158,7 +158,7 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 					SELECT CASE
 						WHEN COUNT(*) = 0 THEN NULL
 						ELSE jsonb_build_object(
-							'currency', MAX(ns.currency),
+							'currency', 'USD',
 							'last_update', to_char(MAX(ns.updated_date), 'YYYY-MM-DD'),
 							'prices', jsonb_agg(
 								jsonb_build_object(
@@ -172,10 +172,10 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 							)
 						)
 					END
-					FROM numbeo_stat ns
-					JOIN numbeo_param np ON np.param_id = ns.param_id
-					JOIN numbeo_category nc ON nc.category_id = np.category_id
-					WHERE ns.city_id = c.city_id
+					FROM numbeo_city_costs ns
+					JOIN numbeo_cost_params np ON np.param_id = ns.param_id
+					JOIN numbeo_cost_categories nc ON nc.category_id = np.category_id
+					WHERE ns.geoname_id = c.geoname_id
 				)
 				ELSE NULL
 			END AS numbeo_cost,
@@ -196,9 +196,9 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 							nic.safety,
 							nic.health_care,
 							nic.pollution,
-							to_char(nic.sys_updated_date, 'YYYY-MM-DD') AS last_update
-						FROM numbeo_index_by_city nic
-						WHERE nic.city_id = c.city_id
+							to_char(nic.updated_date, 'YYYY-MM-DD') AS last_update
+						FROM numbeo_city_indices nic
+						WHERE nic.geoname_id = c.geoname_id
 					) AS n
 				)
 				ELSE NULL
@@ -208,7 +208,7 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 					WITH climate_rows AS (
 						SELECT *
 						FROM avg_climate ac
-						WHERE ac.city_id = c.city_id
+						WHERE ac.geoname_id = c.geoname_id
 					),
 					climate_stats AS (
 						SELECT
@@ -225,10 +225,10 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 						FROM climate_rows cr
 						CROSS JOIN LATERAL jsonb_each(
 							to_jsonb(cr)
-								- 'city_id'
+								- 'geoname_id'
 								- 'month'
-								- 'sys_updated_date'
-								- 'sys_updeted_by'
+								- 'updated_date'
+								- 'updated_by'
 						) AS m(metric_key, metric_value)
 						GROUP BY m.metric_key
 					)
@@ -247,9 +247,9 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 				)
 				ELSE NULL
 			END AS avg_climate
-		FROM city c
-		LEFT JOIN country ctr ON ctr.country_code = c.country_code
-		WHERE c.city_id = $1;`
+		FROM cities c
+		LEFT JOIN countries ctr ON ctr.country_code = c.country_code
+		WHERE c.geoname_id = $1;`
 
 	var (
 		city        City
@@ -318,12 +318,12 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 	}
 
 	query := `
-		SELECT c.city_id, c.city, c.state_code, c.country_code,
+		SELECT c.geoname_id, c.city, c.state_code, c.country_code,
 		       ctr.country AS country
-		FROM city c
-		LEFT JOIN country ctr ON ctr.country_code = c.country_code
-		WHERE c.city_id = ANY($1)
-		ORDER BY c.city_id;`
+		FROM cities c
+		LEFT JOIN countries ctr ON ctr.country_code = c.country_code
+		WHERE c.geoname_id = ANY($1)
+		ORDER BY c.geoname_id;`
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
@@ -390,9 +390,9 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 func (c CityModel) attachNumbeoCostByCityIDs(ctx context.Context, ids []int64, cityByID map[int64]*City) (retErr error) {
 	query := `
 		SELECT
-			ns.city_id,
+			ns.geoname_id,
 			jsonb_build_object(
-				'currency', MAX(ns.currency),
+				'currency', 'USD',
 				'last_update', to_char(MAX(ns.updated_date), 'YYYY-MM-DD'),
 				'prices', jsonb_agg(
 					jsonb_build_object(
@@ -405,11 +405,11 @@ func (c CityModel) attachNumbeoCostByCityIDs(ctx context.Context, ids []int64, c
 					ORDER BY nc.category, np.param
 				)
 			) AS numbeo_cost
-		FROM numbeo_stat ns
-		JOIN numbeo_param np ON np.param_id = ns.param_id
-		JOIN numbeo_category nc ON nc.category_id = np.category_id
-		WHERE ns.city_id = ANY($1)
-		GROUP BY ns.city_id;`
+		FROM numbeo_city_costs ns
+		JOIN numbeo_cost_params np ON np.param_id = ns.param_id
+		JOIN numbeo_cost_categories nc ON nc.category_id = np.category_id
+		WHERE ns.geoname_id = ANY($1)
+		GROUP BY ns.geoname_id;`
 
 	rows, err := c.DB.QueryContext(ctx, query, pq.Array(ids))
 	if err != nil {
@@ -456,9 +456,9 @@ func (c CityModel) attachNumbeoCostByCityIDs(ctx context.Context, ids []int64, c
 func (c CityModel) attachNumbeoCityIndicesByCityIDs(ctx context.Context, ids []int64, cityByID map[int64]*City) (retErr error) {
 	query := `
 		SELECT
-			nic.city_id,
+			nic.geoname_id,
 			row_to_json(n) AS numbeo_indices
-		FROM numbeo_index_by_city nic
+		FROM numbeo_city_indices nic
 		CROSS JOIN LATERAL (
 			SELECT
 				nic.cost_of_living,
@@ -473,9 +473,9 @@ func (c CityModel) attachNumbeoCityIndicesByCityIDs(ctx context.Context, ids []i
 				nic.safety,
 				nic.health_care,
 				nic.pollution,
-				to_char(nic.sys_updated_date, 'YYYY-MM-DD') AS last_update
+				to_char(nic.updated_date, 'YYYY-MM-DD') AS last_update
 		) AS n
-		WHERE nic.city_id = ANY($1);`
+		WHERE nic.geoname_id = ANY($1);`
 
 	rows, err := c.DB.QueryContext(ctx, query, pq.Array(ids))
 	if err != nil {
@@ -524,35 +524,35 @@ func (c CityModel) attachAvgClimateByCityIDs(ctx context.Context, ids []int64, c
 		WITH climate_rows AS (
 			SELECT *
 			FROM avg_climate ac
-			WHERE ac.city_id = ANY($1)
+			WHERE ac.geoname_id = ANY($1)
 		),
 		climate_stats AS (
 			SELECT
-				city_id,
+				geoname_id,
 				COUNT(*) AS row_count,
 				COUNT(DISTINCT month) AS unique_month_count,
 				MIN(month) AS min_month,
 				MAX(month) AS max_month
 			FROM climate_rows
-			GROUP BY city_id
+			GROUP BY geoname_id
 		),
 		climate_data AS (
 			SELECT
-				cr.city_id,
+				cr.geoname_id,
 				m.metric_key,
 				jsonb_agg(m.metric_value ORDER BY cr.month) AS month_values
 			FROM climate_rows cr
 			CROSS JOIN LATERAL jsonb_each(
 				to_jsonb(cr)
-					- 'city_id'
+					- 'geoname_id'
 					- 'month'
-					- 'sys_updated_date'
-					- 'sys_updeted_by'
+					- 'updated_date'
+					- 'updated_by'
 			) AS m(metric_key, metric_value)
-			GROUP BY cr.city_id, m.metric_key
+			GROUP BY cr.geoname_id, m.metric_key
 		)
 		SELECT
-			s.city_id,
+			s.geoname_id,
 			CASE
 				WHEN s.row_count = 12
 					AND s.unique_month_count = 12
@@ -561,7 +561,7 @@ func (c CityModel) attachAvgClimateByCityIDs(ctx context.Context, ids []int64, c
 				THEN (
 					SELECT jsonb_object_agg(cd.metric_key, cd.month_values)
 					FROM climate_data cd
-					WHERE cd.city_id = s.city_id
+					WHERE cd.geoname_id = s.geoname_id
 				)
 				ELSE jsonb_build_object('__invalid_structure__', true)
 			END AS avg_climate

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -18,9 +18,13 @@ func TestListCities(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, len(cities), 534)
-	assert.Equal(t, cities[0].ID, int64(1))
+	assert.Equal(t, len(cities), 527)
+	assert.Equal(t, len(cities) > 0, true)
+	assert.Equal(t, cities[0].ID > 0, true)
+	assert.Equal(t, cities[0].Name != "", true)
+	assert.Equal(t, cities[0].CountryCode != "", true)
 	assert.Equal(t, cities[0].CountryName != "", true)
+
 }
 
 func TestListCitiesWithCountryInclude(t *testing.T) {
@@ -40,12 +44,12 @@ func TestGetCity(t *testing.T) {
 	db := newTestDB(t)
 	models := NewModels(db)
 
-	city, err := models.Cities.GetCity(273, NewIncludeSet("country", "numbeo_cost", "numbeo_indices", "avg_climate"))
+	city, err := models.Cities.GetCity(1850147, NewIncludeSet("country", "numbeo_cost", "numbeo_indices", "avg_climate"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, city.ID, int64(273))
+	assert.Equal(t, city.ID, int64(1850147))
 	assert.Equal(t, city.CountryName, "Japan")
 	assert.Equal(t, city.NumbeoCost != nil, true)
 	assert.Equal(t, city.NumbeoCityIndices != nil, true)
@@ -55,35 +59,35 @@ func TestGetCitiesByIDs(t *testing.T) {
 	db := newTestDB(t)
 	models := NewModels(db)
 
-	cities, err := models.Cities.GetCitiesByIDs([]int64{11, 94, 11}, NewIncludeSet("country"))
+	cities, err := models.Cities.GetCitiesByIDs([]int64{5128581, 6167865, 5128581}, NewIncludeSet("country"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	assert.Equal(t, len(cities), 2)
-	assert.Equal(t, cities[0].ID, int64(11))
+	assert.Equal(t, cities[0].ID, int64(5128581))
 	assert.Equal(t, cities[0].CountryName != "", true)
-	assert.Equal(t, cities[1].ID, int64(94))
+	assert.Equal(t, cities[1].ID, int64(6167865))
 }
 
 func TestGetCityAvgClimateOrderedByMonth(t *testing.T) {
 	db := newTestDB(t)
 	models := NewModels(db)
 
-	var cityID int64
+	var geonameID int64
 	err := db.QueryRow(`
-		SELECT city_id
+		SELECT geoname_id
 		FROM avg_climate
-		GROUP BY city_id
+		GROUP BY geoname_id
 		HAVING COUNT(*) = 12
 		LIMIT 1;
-	`).Scan(&cityID)
+	`).Scan(&geonameID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("testing city_id=%d", cityID)
+	t.Logf("testing geonameid=%d", geonameID)
 
-	city, err := models.Cities.GetCity(cityID, NewIncludeSet("avg_climate"))
+	city, err := models.Cities.GetCity(geonameID, NewIncludeSet("avg_climate"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -95,8 +99,8 @@ func TestGetCityAvgClimateOrderedByMonth(t *testing.T) {
 	rows, err := db.Query(`
 		SELECT month, high_temp
 		FROM avg_climate
-		WHERE city_id = $1
-		ORDER BY month;`, cityID)
+		WHERE geoname_id = $1
+		ORDER BY month;`, geonameID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -126,7 +130,7 @@ func TestGetCityAvgClimateOrderedByMonth(t *testing.T) {
 	assert.Equal(t, len(city.AvgClimate.HighTemp), 12)
 	for i := range expected {
 		if !equalFloatPtrs(expected[i], city.AvgClimate.HighTemp[i]) {
-			t.Fatalf("city_id=%d high_temp[%d] mismatch: got=%v want=%v", cityID, i, city.AvgClimate.HighTemp[i], expected[i])
+			t.Fatalf("geonameid=%d high_temp[%d] mismatch: got=%v want=%v", geonameID, i, city.AvgClimate.HighTemp[i], expected[i])
 		}
 	}
 }
@@ -135,20 +139,20 @@ func TestGetCityAvgClimateSeaTempAllNull(t *testing.T) {
 	db := newTestDB(t)
 	models := NewModels(db)
 
-	var cityID int64
+	var geonameID int64
 	err := db.QueryRow(`
-		SELECT city_id
+		SELECT geoname_id
 		FROM avg_climate
-		GROUP BY city_id
+		GROUP BY geoname_id
 		HAVING COUNT(*) = 12 AND COUNT(sea_temp) = 0
 		LIMIT 1;
-	`).Scan(&cityID)
+	`).Scan(&geonameID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Logf("testing city_id=%d", cityID)
+	t.Logf("testing geonameid=%d", geonameID)
 
-	city, err := models.Cities.GetCity(cityID, NewIncludeSet("avg_climate"))
+	city, err := models.Cities.GetCity(geonameID, NewIncludeSet("avg_climate"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +163,7 @@ func TestGetCityAvgClimateSeaTempAllNull(t *testing.T) {
 	assert.Equal(t, len(city.AvgClimate.SeaTemp), 12)
 	for i, value := range city.AvgClimate.SeaTemp {
 		if value != nil {
-			t.Fatalf("city_id=%d expected sea_temp[%d] to be nil, got %v", cityID, i, *value)
+			t.Fatalf("geonameid=%d expected sea_temp[%d] to be nil, got %v", geonameID, i, *value)
 		}
 	}
 }

--- a/internal/data/countries.go
+++ b/internal/data/countries.go
@@ -94,7 +94,7 @@ type CountryModel struct {
 func (c CountryModel) ListCountries() (countries []*Country, retErr error) {
 	query := `
 		SELECT country_code, country
-		FROM country
+		FROM countries
 		ORDER BY country_code;`
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -150,8 +150,8 @@ func (c CountryModel) GetCountry(countryCode string, include IncludeSet) (*Count
 							nic.health_care,
 							nic.pollution,
 							nic.avg_salary_usd,
-							to_char(nic.sys_updated_date, 'YYYY-MM-DD') AS last_update
-						FROM numbeo_index_by_country nic
+							to_char(nic.updated_date, 'YYYY-MM-DD') AS last_update
+						FROM numbeo_country_indices nic
 						WHERE nic.country_code = ctr.country_code
 					) AS n
 				)
@@ -177,14 +177,14 @@ func (c CountryModel) GetCountry(countryCode string, include IncludeSet) (*Count
 								WHEN 'Natural Environment' THEN 'natural_environment'
 							END AS key,
 							to_jsonb(li) - 'country_code' - 'pillar_name' AS value
-						FROM legatum_index li
+						FROM legatum_country_indices li
 						WHERE li.country_code = ctr.country_code
 					) AS l
 					WHERE l.key IS NOT NULL
 				)
 				ELSE NULL
 			END AS legatum_indices
-		FROM country ctr
+		FROM countries ctr
 		WHERE ctr.country_code = $1;`
 
 	var (
@@ -241,7 +241,7 @@ func (c CountryModel) GetCountriesByCodes(codes []string, include IncludeSet) (c
 
 	query := `
 		SELECT ctr.country_code, ctr.country
-		FROM country ctr
+		FROM countries ctr
 		WHERE ctr.country_code = ANY($1)
 		ORDER BY ctr.country_code;`
 
@@ -299,7 +299,7 @@ func (c CountryModel) attachNumbeoIndicesByCodes(ctx context.Context, codes []st
 		SELECT
 			nic.country_code,
 			row_to_json(n) AS numbeo_indices
-		FROM numbeo_index_by_country nic
+		FROM numbeo_country_indices nic
 		CROSS JOIN LATERAL (
 			SELECT
 				nic.cost_of_living,
@@ -316,7 +316,7 @@ func (c CountryModel) attachNumbeoIndicesByCodes(ctx context.Context, codes []st
 				nic.health_care,
 				nic.pollution,
 				nic.avg_salary_usd,
-				to_char(nic.sys_updated_date, 'YYYY-MM-DD') AS last_update
+				to_char(nic.updated_date, 'YYYY-MM-DD') AS last_update
 		) AS n
 		WHERE nic.country_code = ANY($1);`
 
@@ -367,7 +367,7 @@ func (c CountryModel) attachLegatumIndicesByCodes(ctx context.Context, codes []s
 		SELECT
 			li.country_code,
 			jsonb_object_agg(l.key, l.value) AS legatum_indices
-		FROM legatum_index li
+		FROM legatum_country_indices li
 		CROSS JOIN LATERAL (
 			SELECT
 				CASE li.pillar_name


### PR DESCRIPTION
## Summary
Aligns the API data layer and test suite with the new 2026 PostgreSQL schema. This updates renamed tables and columns, switches city lookups to `geoname_id`, preserves existing response shapes where needed, and rewrites brittle dataset-dependent tests to be more stable against the new data snapshot.

## Changes
- Updated DAL SQL to match renamed tables in the new schema:
1. `city` -> `cities`
2. `country` -> `countries`
3. `legatum_index` -> `legatum_country_indices`
4. `numbeo_stat` -> `numbeo_city_costs`
5. `numbeo_param` -> `numbeo_cost_params`
6. `numbeo_category` -> `numbeo_cost_categories`
7. `numbeo_index_by_city` -> `numbeo_city_indices`
8. `numbeo_index_by_country` -> `numbeo_country_indices`
- Updated city-side SQL from `city_id` to `geoname_id` where it represents the database key.
- Updated renamed timestamp/audit columns:
1. `sys_updated_date` -> `updated_date`
2. `sys_updated_by` / `sys_updeted_by` -> `updated_by`
- Preserved `numbeo_cost.currency` in API responses by hardcoding `USD` in SQL, since the new schema no longer stores a `currency` column.
- Changed external city JSON field name from `city_id` to `geoname_id`:
1. direct `data.City` serialization
2. mapped `cityResponse` serialization
- Adapted tests to the new schema and dataset:
1. replaced hardcoded old city IDs with new `geoname_id` values where mappings were provided
2. removed brittle “ID as array index” lookup in city list tests
3. converted country/include tests away from stale hardcoded fixtures toward dynamic lookup where needed
4. rewrote city-country count assertions to avoid relying on obsolete fixed dataset counts
5. fixed the broken climate test SQL (`HAVING COUNT(*) = 12`)

## Validation
- `make test`