### PR TITLE
feat(data): add core city and country fields from the new schema

### DIFF
--- a/cmd/api/response_mappers.go
+++ b/cmd/api/response_mappers.go
@@ -20,7 +20,7 @@ type cityResponse struct {
 
 func newCityResponse(city *data.City, include data.IncludeSet) cityResponse {
 	res := cityResponse{
-		CityID:      city.ID,
+		CityID:      city.GeonameID,
 		City:        city.Name,
 		StateCode:   city.StateCode,
 		CountryCode: city.CountryCode,

--- a/cmd/api/response_mappers.go
+++ b/cmd/api/response_mappers.go
@@ -8,6 +8,11 @@ type cityResponse struct {
 	StateCode     *string `json:"state_code"`
 	CountryCode   string  `json:"country_code"`
 	Country       string  `json:"country,omitzero"`
+	Population    *int64  `json:"population,omitzero"`
+	Latitude      float64 `json:"latitude"`
+	Longitude     float64 `json:"longitude"`
+	Timezone      string  `json:"timezone"`
+	LastUpdate    string  `json:"last_update"`
 	NumbeoCost    any     `json:"numbeo_cost,omitempty"`
 	NumbeoIndices any     `json:"numbeo_indices,omitempty"`
 	AvgClimate    any     `json:"avg_climate,omitempty"`
@@ -20,6 +25,11 @@ func newCityResponse(city *data.City, include data.IncludeSet) cityResponse {
 		StateCode:   city.StateCode,
 		CountryCode: city.CountryCode,
 		Country:     city.CountryName,
+		Population:  city.Population,
+		Latitude:    city.Latitude,
+		Longitude:   city.Longitude,
+		Timezone:    city.Timezone,
+		LastUpdate:  city.LastUpdate,
 	}
 
 	if include.Has("numbeo_cost") {
@@ -38,14 +48,20 @@ func newCityResponse(city *data.City, include data.IncludeSet) cityResponse {
 type countryResponse struct {
 	Code           string `json:"country_code"`
 	Name           string `json:"country"`
+	Population     *int64 `json:"population,omitzero"`
+	Area           *int64 `json:"area,omitzero"`
+	LastUpdate     string `json:"last_update"`
 	NumbeoIndices  any    `json:"numbeo_indices,omitempty"`
 	LegatumIndices any    `json:"legatum_indices,omitempty"`
 }
 
 func newCountryResponse(country *data.Country, include data.IncludeSet) countryResponse {
 	res := countryResponse{
-		Code: country.Code,
-		Name: country.Name,
+		Code:       country.Code,
+		Name:       country.Name,
+		Population: country.Population,
+		Area:       country.Area,
+		LastUpdate: country.LastUpdate,
 	}
 
 	if include.Has("numbeo_indices") {

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -53,7 +53,7 @@ func findCityByID(t *testing.T, cities []data.City, id int64) data.City {
 	t.Helper()
 
 	for _, city := range cities {
-		if city.ID == id {
+		if city.GeonameID == id {
 			return city
 		}
 	}
@@ -73,7 +73,7 @@ func fetchExpectedCity(t *testing.T, geonameID int64) data.City {
 		FROM cities c
 		LEFT JOIN countries ctr ON ctr.country_code = c.country_code
 		WHERE c.geoname_id = $1;`, geonameID).Scan(
-		&city.ID,
+		&city.GeonameID,
 		&city.Name,
 		&city.StateCode,
 		&city.CountryCode,
@@ -228,9 +228,9 @@ func TestCitiesBatchByIDs(t *testing.T) {
 	var got gotResponse
 	unmarshalJSON(t, body, &got)
 	assert.Equal(t, len(got.Cities), 2)
-	assert.Equal(t, got.Cities[0].ID, int64(5128581))
+	assert.Equal(t, got.Cities[0].GeonameID, int64(5128581))
 	assert.Equal(t, got.Cities[0].CountryName, "United States of America")
-	assert.Equal(t, got.Cities[1].ID, int64(6167865))
+	assert.Equal(t, got.Cities[1].GeonameID, int64(6167865))
 	assert.Equal(t, got.Cities[1].CountryName, "Canada")
 }
 

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -42,31 +42,10 @@ func TestCities(t *testing.T) {
 	unmarshalJSON(t, body, &got)
 	assert.Equal(t, len(got.Cities) > 0, true)
 
-	wantCities := []data.City{
-		{
-			ID:          5128581,
-			Name:        "New York",
-			StateCode:   ptrString("US-NY"),
-			CountryCode: "USA",
-			CountryName: "United States of America",
-		},
-		{
-			ID:          6167865,
-			Name:        "Toronto",
-			StateCode:   nil,
-			CountryCode: "CAN",
-			CountryName: "Canada",
-		},
-		{
-			ID:          524901,
-			Name:        "Moscow",
-			StateCode:   nil,
-			CountryCode: "RUS",
-			CountryName: "Russian Federation",
-		},
-	}
-	for _, city := range wantCities {
-		assert.DeepEqual(t, findCityByID(t, got.Cities, city.ID), city)
+	for _, geonameID := range []int64{5128581, 6167865, 524901} {
+		gotCity := findCityByID(t, got.Cities, geonameID)
+		wantCity := fetchExpectedCity(t, geonameID)
+		assert.DeepEqual(t, gotCity, wantCity)
 	}
 }
 
@@ -81,6 +60,56 @@ func findCityByID(t *testing.T, cities []data.City, id int64) data.City {
 
 	t.Fatalf("city with id=%d not found in response", id)
 	return data.City{}
+}
+
+func fetchExpectedCity(t *testing.T, geonameID int64) data.City {
+	t.Helper()
+
+	var city data.City
+	err := testDB.QueryRow(`
+		SELECT c.geoname_id, c.city, c.state_code, c.country_code, ctr.country,
+		       c.population, c.latitude, c.longitude, c.timezone,
+		       to_char(c.updated_date, 'YYYY-MM-DD') AS last_update
+		FROM cities c
+		LEFT JOIN countries ctr ON ctr.country_code = c.country_code
+		WHERE c.geoname_id = $1;`, geonameID).Scan(
+		&city.ID,
+		&city.Name,
+		&city.StateCode,
+		&city.CountryCode,
+		&city.CountryName,
+		&city.Population,
+		&city.Latitude,
+		&city.Longitude,
+		&city.Timezone,
+		&city.LastUpdate,
+	)
+	if err != nil {
+		t.Fatalf("failed to fetch expected city %d: %v", geonameID, err)
+	}
+
+	return city
+}
+
+func fetchExpectedCountry(t *testing.T, code string) data.Country {
+	t.Helper()
+
+	var country data.Country
+	err := testDB.QueryRow(`
+		SELECT country_code, country, population, area, last_update::text
+		FROM countries
+		WHERE country_code = UPPER($1);`, code).Scan(
+		&country.Code,
+		&country.Name,
+		&country.Population,
+		&country.Area,
+		&country.LastUpdate,
+	)
+	if err != nil {
+		t.Fatalf("failed to fetch expected country %s: %v", code, err)
+	}
+
+	return country
 }
 
 // TestCities tests the “/cities” endpoint with query parameter.
@@ -248,31 +277,19 @@ func TestCityID(t *testing.T) {
 		name       string
 		urlPath    string
 		statusCode int
-		city       data.City
+		id         int64
 	}{
 		{
 			name:       "Valid ID (No query params)",
 			urlPath:    "/cities/5809844",
 			statusCode: http.StatusOK,
-			city: data.City{
-				ID:          5809844,
-				Name:        "Seattle",
-				StateCode:   ptrString("US-WA"),
-				CountryCode: "USA",
-				CountryName: "United States of America",
-			},
+			id:         5809844,
 		},
 		{
 			name:       "Valid ID with include query",
 			urlPath:    "/cities/1850147?include=country",
 			statusCode: http.StatusOK,
-			city: data.City{
-				ID:          1850147,
-				Name:        "Tokyo",
-				StateCode:   nil,
-				CountryCode: "JPN",
-				CountryName: "Japan",
-			},
+			id:         1850147,
 		},
 		{
 			name:       "Non-existent ID",
@@ -309,7 +326,9 @@ func TestCityID(t *testing.T) {
 
 			var got gotResponse
 			unmarshalJSON(t, body, &got)
-			assert.DeepEqual(t, got.City, tt.city)
+			if tt.statusCode == http.StatusOK {
+				assert.DeepEqual(t, got.City, fetchExpectedCity(t, tt.id))
+			}
 
 			if tt.statusCode == http.StatusNotFound {
 				assert.Equal(t, got.Error, "the requested resource could not be found")
@@ -732,38 +751,24 @@ func TestCountries(t *testing.T) {
 	unmarshalJSON(t, body, &got)
 	assert.Equal(t, len(got.Countries), 249)
 
-	tests := []struct {
-		index   int
-		country data.Country
-	}{
-		{
-			index: 14,
-			country: data.Country{
-				Code: "AUS",
-				Name: "Australia",
-			},
-		},
-		{
-			index: 111,
-			country: data.Country{
-				Code: "ITA",
-				Name: "Italy",
-			},
-		},
-		{
-			index: 218,
-			country: data.Country{
-				Code: "THA",
-				Name: "Thailand",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("Check country code=%s", tt.country.Code), func(t *testing.T) {
-			assert.DeepEqual(t, got.Countries[tt.index], tt.country)
+	for _, code := range []string{"AUS", "ITA", "THA"} {
+		t.Run(fmt.Sprintf("Check country code=%s", code), func(t *testing.T) {
+			assert.DeepEqual(t, findCountryByCode(t, got.Countries, code), fetchExpectedCountry(t, code))
 		})
 	}
+}
+
+func findCountryByCode(t *testing.T, countries []data.Country, code string) data.Country {
+	t.Helper()
+
+	for _, country := range countries {
+		if country.Code == code {
+			return country
+		}
+	}
+
+	t.Fatalf("country with code=%s not found in response", code)
+	return data.Country{}
 }
 
 // TestCountriesBatchByCodes tests batch retrieval for "/countries?country_codes=...".
@@ -831,34 +836,25 @@ func TestCountry(t *testing.T) {
 		name       string
 		urlPath    string
 		statusCode int
-		country    data.Country
+		code       string
 	}{
 		{
 			name:       "Valid uppercase code (AUS)",
 			urlPath:    "/countries/AUS",
 			statusCode: http.StatusOK,
-			country: data.Country{
-				Code: "AUS",
-				Name: "Australia",
-			},
+			code:       "AUS",
 		},
 		{
 			name:       "Valid mixed case code (iTa)",
 			urlPath:    "/countries/iTa",
 			statusCode: http.StatusOK,
-			country: data.Country{
-				Code: "ITA",
-				Name: "Italy",
-			},
+			code:       "ITA",
 		},
 		{
 			name:       "Valid lowercase code (tha)",
 			urlPath:    "/countries/tha",
 			statusCode: http.StatusOK,
-			country: data.Country{
-				Code: "THA",
-				Name: "Thailand",
-			},
+			code:       "THA",
 		},
 		{
 			name:       "Nonexistent country code (XXX)",
@@ -910,7 +906,9 @@ func TestCountry(t *testing.T) {
 
 			var got gotResponse
 			unmarshalJSON(t, body, &got)
-			assert.DeepEqual(t, got.Country, tt.country)
+			if tt.statusCode == http.StatusOK {
+				assert.DeepEqual(t, got.Country, fetchExpectedCountry(t, tt.code))
+			}
 
 			switch tt.statusCode {
 			case http.StatusUnprocessableEntity:

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -12,7 +12,7 @@ import (
 )
 
 type City struct {
-	ID                int64              `json:"geoname_id"`
+	GeonameID         int64              `json:"geoname_id"`
 	Name              string             `json:"city"`
 	StateCode         *string            `json:"state_code"`
 	CountryCode       string             `json:"country_code"`
@@ -126,7 +126,7 @@ func (c CityModel) ListCities(countryCode string, include IncludeSet) (cities []
 	for rows.Next() {
 		var city City
 		if err := rows.Scan(
-			&city.ID,
+			&city.GeonameID,
 			&city.Name,
 			&city.StateCode,
 			&city.CountryCode,
@@ -285,7 +285,7 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 		include.Has("numbeo_indices"),
 		include.Has("avg_climate"),
 	).Scan(
-		&city.ID,
+		&city.GeonameID,
 		&city.Name,
 		&city.StateCode,
 		&city.CountryCode,
@@ -365,7 +365,7 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 	for rows.Next() {
 		var city City
 		if err := rows.Scan(
-			&city.ID,
+			&city.GeonameID,
 			&city.Name,
 			&city.StateCode,
 			&city.CountryCode,
@@ -380,7 +380,7 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 		}
 		cityPtr := &city
 		cities = append(cities, cityPtr)
-		cityByID[city.ID] = cityPtr
+		cityByID[city.GeonameID] = cityPtr
 	}
 
 	if err = rows.Err(); err != nil {

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -17,6 +17,11 @@ type City struct {
 	StateCode         *string            `json:"state_code"`
 	CountryCode       string             `json:"country_code"`
 	CountryName       string             `json:"country,omitzero"`
+	Population        *int64             `json:"population,omitzero"`
+	Latitude          float64            `json:"latitude"`
+	Longitude         float64            `json:"longitude"`
+	Timezone          string             `json:"timezone"`
+	LastUpdate        string             `json:"last_update"`
 	NumbeoCost        *NumbeoCost        `json:"numbeo_cost,omitzero"`
 	NumbeoCityIndices *NumbeoCityIndices `json:"numbeo_indices,omitzero"`
 	AvgClimate        *AvgClimate        `json:"avg_climate,omitzero"`
@@ -97,7 +102,8 @@ type CityModel struct {
 func (c CityModel) ListCities(countryCode string, include IncludeSet) (cities []*City, retErr error) {
 	query := `
 		SELECT c.geoname_id, c.city, c.state_code, c.country_code,
-		       ctr.country AS country
+		       ctr.country AS country, c.population, c.latitude, c.longitude, c.timezone,
+		       to_char(c.updated_date, 'YYYY-MM-DD') AS last_update
 		FROM cities c
 		LEFT JOIN countries ctr ON ctr.country_code = c.country_code
 		WHERE (LOWER(c.country_code) = LOWER($1) OR $1 = '')
@@ -125,6 +131,11 @@ func (c CityModel) ListCities(countryCode string, include IncludeSet) (cities []
 			&city.StateCode,
 			&city.CountryCode,
 			&city.CountryName,
+			&city.Population,
+			&city.Latitude,
+			&city.Longitude,
+			&city.Timezone,
+			&city.LastUpdate,
 		); err != nil {
 			return nil, err
 		}
@@ -153,6 +164,11 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 			c.state_code,
 			c.country_code,
 			ctr.country AS country,
+			c.population,
+			c.latitude,
+			c.longitude,
+			c.timezone,
+			to_char(c.updated_date, 'YYYY-MM-DD') AS last_update,
 			CASE
 				WHEN $2 THEN (
 					SELECT CASE
@@ -274,6 +290,11 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 		&city.StateCode,
 		&city.CountryCode,
 		&city.CountryName,
+		&city.Population,
+		&city.Latitude,
+		&city.Longitude,
+		&city.Timezone,
+		&city.LastUpdate,
 		&costJSON,
 		&indicesJSON,
 		&climateJSON,
@@ -319,7 +340,8 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 
 	query := `
 		SELECT c.geoname_id, c.city, c.state_code, c.country_code,
-		       ctr.country AS country
+		       ctr.country AS country, c.population, c.latitude, c.longitude, c.timezone,
+		       to_char(c.updated_date, 'YYYY-MM-DD') AS last_update
 		FROM cities c
 		LEFT JOIN countries ctr ON ctr.country_code = c.country_code
 		WHERE c.geoname_id = ANY($1)
@@ -348,6 +370,11 @@ func (c CityModel) GetCitiesByIDs(ids []int64, include IncludeSet) (cities []*Ci
 			&city.StateCode,
 			&city.CountryCode,
 			&city.CountryName,
+			&city.Population,
+			&city.Latitude,
+			&city.Longitude,
+			&city.Timezone,
+			&city.LastUpdate,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/data/cities.go
+++ b/internal/data/cities.go
@@ -175,7 +175,7 @@ func (c CityModel) GetCity(id int64, include IncludeSet) (*City, error) {
 						WHEN COUNT(*) = 0 THEN NULL
 						ELSE jsonb_build_object(
 							'currency', 'USD',
-							'last_update', to_char(MAX(ns.updated_date), 'YYYY-MM-DD'),
+							'last_update', MAX(ns.last_update)::text,
 							'prices', jsonb_agg(
 								jsonb_build_object(
 									'category', nc.category,
@@ -420,7 +420,7 @@ func (c CityModel) attachNumbeoCostByCityIDs(ctx context.Context, ids []int64, c
 			ns.geoname_id,
 			jsonb_build_object(
 				'currency', 'USD',
-				'last_update', to_char(MAX(ns.updated_date), 'YYYY-MM-DD'),
+				'last_update', MAX(ns.last_update)::text,
 				'prices', jsonb_agg(
 					jsonb_build_object(
 						'category', nc.category,

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -20,7 +20,7 @@ func TestListCities(t *testing.T) {
 
 	assert.Equal(t, len(cities), 527)
 	assert.Equal(t, len(cities) > 0, true)
-	assert.Equal(t, cities[0].ID > 0, true)
+	assert.Equal(t, cities[0].GeonameID > 0, true)
 	assert.Equal(t, cities[0].Name != "", true)
 	assert.Equal(t, cities[0].CountryCode != "", true)
 	assert.Equal(t, cities[0].CountryName != "", true)
@@ -52,7 +52,7 @@ func TestGetCity(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, city.ID, int64(1850147))
+	assert.Equal(t, city.GeonameID, int64(1850147))
 	assert.Equal(t, city.CountryName, "Japan")
 	assert.Equal(t, city.Latitude != 0, true)
 	assert.Equal(t, city.Longitude != 0, true)
@@ -72,10 +72,10 @@ func TestGetCitiesByIDs(t *testing.T) {
 	}
 
 	assert.Equal(t, len(cities), 2)
-	assert.Equal(t, cities[0].ID, int64(5128581))
+	assert.Equal(t, cities[0].GeonameID, int64(5128581))
 	assert.Equal(t, cities[0].CountryName != "", true)
 	assert.Equal(t, cities[0].Timezone != "", true)
-	assert.Equal(t, cities[1].ID, int64(6167865))
+	assert.Equal(t, cities[1].GeonameID, int64(6167865))
 }
 
 func TestGetCityAvgClimateOrderedByMonth(t *testing.T) {

--- a/internal/data/cities_test.go
+++ b/internal/data/cities_test.go
@@ -24,7 +24,10 @@ func TestListCities(t *testing.T) {
 	assert.Equal(t, cities[0].Name != "", true)
 	assert.Equal(t, cities[0].CountryCode != "", true)
 	assert.Equal(t, cities[0].CountryName != "", true)
-
+	assert.Equal(t, cities[0].Latitude != 0, true)
+	assert.Equal(t, cities[0].Longitude != 0, true)
+	assert.Equal(t, cities[0].Timezone != "", true)
+	assert.Equal(t, cities[0].LastUpdate != "", true)
 }
 
 func TestListCitiesWithCountryInclude(t *testing.T) {
@@ -51,6 +54,10 @@ func TestGetCity(t *testing.T) {
 
 	assert.Equal(t, city.ID, int64(1850147))
 	assert.Equal(t, city.CountryName, "Japan")
+	assert.Equal(t, city.Latitude != 0, true)
+	assert.Equal(t, city.Longitude != 0, true)
+	assert.Equal(t, city.Timezone != "", true)
+	assert.Equal(t, city.LastUpdate != "", true)
 	assert.Equal(t, city.NumbeoCost != nil, true)
 	assert.Equal(t, city.NumbeoCityIndices != nil, true)
 }
@@ -67,6 +74,7 @@ func TestGetCitiesByIDs(t *testing.T) {
 	assert.Equal(t, len(cities), 2)
 	assert.Equal(t, cities[0].ID, int64(5128581))
 	assert.Equal(t, cities[0].CountryName != "", true)
+	assert.Equal(t, cities[0].Timezone != "", true)
 	assert.Equal(t, cities[1].ID, int64(6167865))
 }
 

--- a/internal/data/countries.go
+++ b/internal/data/countries.go
@@ -13,6 +13,9 @@ import (
 type Country struct {
 	Code                  string                 `json:"country_code"`
 	Name                  string                 `json:"country"`
+	Population            *int64                 `json:"population,omitzero"`
+	Area                  *int64                 `json:"area,omitzero"`
+	LastUpdate            string                 `json:"last_update"`
 	NumbeoCountryIndices  *NumbeoCountryIndices  `json:"numbeo_indices,omitempty"`
 	LegatumCountryIndices *LegatumCountryIndices `json:"legatum_indices,omitempty"`
 }
@@ -93,7 +96,7 @@ type CountryModel struct {
 
 func (c CountryModel) ListCountries() (countries []*Country, retErr error) {
 	query := `
-		SELECT country_code, country
+		SELECT country_code, country, population, area, last_update::text
 		FROM countries
 		ORDER BY country_code;`
 
@@ -113,7 +116,7 @@ func (c CountryModel) ListCountries() (countries []*Country, retErr error) {
 	countries = []*Country{}
 	for rows.Next() {
 		var country Country
-		if err := rows.Scan(&country.Code, &country.Name); err != nil {
+		if err := rows.Scan(&country.Code, &country.Name, &country.Population, &country.Area, &country.LastUpdate); err != nil {
 			return nil, err
 		}
 		countries = append(countries, &country)
@@ -131,6 +134,9 @@ func (c CountryModel) GetCountry(countryCode string, include IncludeSet) (*Count
 		SELECT
 			ctr.country_code,
 			ctr.country,
+			ctr.population,
+			ctr.area,
+			ctr.last_update::text AS last_update,
 			CASE
 				WHEN $2 THEN (
 					SELECT row_to_json(n)
@@ -205,6 +211,9 @@ func (c CountryModel) GetCountry(countryCode string, include IncludeSet) (*Count
 	).Scan(
 		&country.Code,
 		&country.Name,
+		&country.Population,
+		&country.Area,
+		&country.LastUpdate,
 		&numbeoJSON,
 		&legatumJSON,
 	)
@@ -240,7 +249,7 @@ func (c CountryModel) GetCountriesByCodes(codes []string, include IncludeSet) (c
 	}
 
 	query := `
-		SELECT ctr.country_code, ctr.country
+		SELECT ctr.country_code, ctr.country, ctr.population, ctr.area, ctr.last_update::text AS last_update
 		FROM countries ctr
 		WHERE ctr.country_code = ANY($1)
 		ORDER BY ctr.country_code;`
@@ -262,7 +271,7 @@ func (c CountryModel) GetCountriesByCodes(codes []string, include IncludeSet) (c
 	countryByCode := make(map[string]*Country, len(codes))
 	for rows.Next() {
 		var country Country
-		if err := rows.Scan(&country.Code, &country.Name); err != nil {
+		if err := rows.Scan(&country.Code, &country.Name, &country.Population, &country.Area, &country.LastUpdate); err != nil {
 			return nil, err
 		}
 		countryPtr := &country

--- a/internal/data/countries_test.go
+++ b/internal/data/countries_test.go
@@ -19,6 +19,7 @@ func TestListCountries(t *testing.T) {
 
 	assert.Equal(t, len(countries), 249)
 	assert.Equal(t, countries[0].Code != "", true)
+	assert.Equal(t, countries[0].LastUpdate != "", true)
 }
 
 func TestGetCountry(t *testing.T) {
@@ -31,6 +32,7 @@ func TestGetCountry(t *testing.T) {
 	}
 
 	assert.Equal(t, country.Code, "USA")
+	assert.Equal(t, country.LastUpdate != "", true)
 	assert.Equal(t, country.NumbeoCountryIndices != nil, true)
 	assert.Equal(t, country.LegatumCountryIndices != nil, true)
 }
@@ -46,5 +48,6 @@ func TestGetCountriesByCodes(t *testing.T) {
 
 	assert.Equal(t, len(countries), 2)
 	assert.Equal(t, countries[0].Code, "RUS")
+	assert.Equal(t, countries[0].LastUpdate != "", true)
 	assert.Equal(t, countries[1].Code, "USA")
 }


### PR DESCRIPTION
## Summary
Adds new core city and country fields from the 2026 database schema and wires them through the full stack: DAL queries, API responses, and tests. The main change is expanding the baseline city/country payloads with data already present in the database, while aligning the code with the updated schema.

## Changes
- Added new baseline city fields to API responses:
1. `population`
2. `latitude`
3. `longitude`
4. `timezone`
5. `last_update`
- Added new baseline country fields to API responses:
1. `population`
2. `area`
3. `last_update`
- Updated DAL SQL and scans so the new fields are loaded in:
1. city list
2. city detail
3. city batch
4. country list
5. country detail
6. country batch
- Updated response mappers so the new baseline fields are included consistently in API JSON.
- Aligned code and tests with the new schema:
1. city identifier renamed to `GeonameID` in the city domain model
2. city JSON field exposed as `geoname_id`
3. tests updated to compare exact expected values from the database where appropriate
- Small follow-up cleanups:
1. `numbeo_city_costs.last_update` is now used directly
2. test fixtures were adjusted to the new schema and dataset

## Validation
- `make test`