### PR TITLE
feat(db): add functional index for city country_code filtering

### DIFF
--- a/migrations/000004_add_domain_indexes.down.sql
+++ b/migrations/000004_add_domain_indexes.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS public.idx_cities_country_code_lower;

--- a/migrations/000004_add_domain_indexes.up.sql
+++ b/migrations/000004_add_domain_indexes.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_cities_country_code_lower
+ON public.cities (LOWER(country_code));


### PR DESCRIPTION
## Summary
Adds a functional index to support case-insensitive city filtering by `country_code`.

## Changes
- Added `idx_cities_country_code_lower` on `LOWER(country_code)` for `cities`.
- This matches the current `ListCities` query pattern:
1. `WHERE LOWER(c.country_code) = LOWER($1)`

## Validation
- reviewed against current SQL usage in the API data layer