### PR TITLE
feat(observability): improve API request tracing, readiness, and lightweight metrics

### DIFF
--- a/cmd/api/errors.go
+++ b/cmd/api/errors.go
@@ -6,12 +6,14 @@ import (
 )
 
 func (app *application) logError(r *http.Request, err error) {
-	var (
-		method = r.Method
-		uri    = r.URL.RequestURI()
+	app.logger.Error(
+		err.Error(),
+		"request_id", app.contextGetRequestID(r),
+		"method", r.Method,
+		"path", r.URL.Path,
+		"route", requestRoute(r),
+		"uri", r.URL.RequestURI(),
 	)
-
-	app.logger.Error(err.Error(), "method", method, "uri", uri)
 }
 
 func (app *application) errorResponse(w http.ResponseWriter, r *http.Request, status int, message any) {

--- a/cmd/api/healthcheck.go
+++ b/cmd/api/healthcheck.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"context"
 	"net/http"
+	"time"
 )
 
 func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Request) {
@@ -21,6 +23,43 @@ func (app *application) healthcheckHandler(w http.ResponseWriter, r *http.Reques
 
 	err = app.writeJSON(w, http.StatusOK, env, nil)
 	if err != nil {
+		app.serverErrorResponse(w, r, err)
+	}
+}
+
+func (app *application) readinessHandler(w http.ResponseWriter, r *http.Request) {
+	err := validateAllowedQueryParams(r.URL.Query(), newIncludeSet())
+	if err != nil {
+		app.failedValidationResponse(w, r, map[string]string{"query": err.Error()})
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), time.Second)
+	defer cancel()
+
+	if err := app.db.PingContext(ctx); err != nil {
+		env := envelope{
+			"status": "not ready",
+			"checks": map[string]string{
+				"database": "unavailable",
+			},
+		}
+
+		if writeErr := app.writeJSON(w, http.StatusServiceUnavailable, env, nil); writeErr != nil {
+			app.serverErrorResponse(w, r, writeErr)
+		}
+
+		return
+	}
+
+	env := envelope{
+		"status": "ready",
+		"checks": map[string]string{
+			"database": "available",
+		},
+	}
+
+	if err := app.writeJSON(w, http.StatusOK, env, nil); err != nil {
 		app.serverErrorResponse(w, r, err)
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -58,6 +58,7 @@ type config struct {
 type application struct {
 	config config
 	logger *slog.Logger
+	db     *sql.DB
 	models data.Models
 	mailer mailer.Mailer
 	wg     sync.WaitGroup
@@ -94,6 +95,7 @@ func run() error {
 	app := &application{
 		config: cfg,
 		logger: logger,
+		db:     db,
 		models: data.NewModels(db),
 		mailer: mailer.NewSMTPMailer(cfg.smtp.host, cfg.smtp.port, cfg.smtp.username, cfg.smtp.password, cfg.smtp.sender),
 	}

--- a/cmd/api/observability.go
+++ b/cmd/api/observability.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"expvar"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const requestIDHeader = "X-Request-ID"
+
+const requestIDContextKey = contextKey("request_id")
+
+var (
+	totalRequestsMetric = expvar.NewInt("total_requests")
+	responses2xxMetric  = expvar.NewInt("responses_2xx_total")
+	responses4xxMetric  = expvar.NewInt("responses_4xx_total")
+	responses5xxMetric  = expvar.NewInt("responses_5xx_total")
+)
+
+func (app *application) contextSetRequestID(r *http.Request, requestID string) *http.Request {
+	ctx := context.WithValue(r.Context(), requestIDContextKey, requestID)
+	return r.WithContext(ctx)
+}
+
+func (app *application) contextGetRequestID(r *http.Request) string {
+	requestID, ok := r.Context().Value(requestIDContextKey).(string)
+	if !ok || requestID == "" {
+		return ""
+	}
+
+	return requestID
+}
+
+func (app *application) requestID(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestID := r.Header.Get(requestIDHeader)
+		if requestID == "" {
+			requestID = newRequestID()
+		}
+
+		w.Header().Set(requestIDHeader, requestID)
+		next.ServeHTTP(w, app.contextSetRequestID(r, requestID))
+	})
+}
+
+func (app *application) logRequest(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		recorder := &statusRecorder{ResponseWriter: w, statusCode: http.StatusOK}
+
+		next.ServeHTTP(recorder, r)
+
+		duration := time.Since(start)
+		requestID := app.contextGetRequestID(r)
+
+		totalRequestsMetric.Add(1)
+		switch recorder.statusCode / 100 {
+		case 2:
+			responses2xxMetric.Add(1)
+		case 4:
+			responses4xxMetric.Add(1)
+		case 5:
+			responses5xxMetric.Add(1)
+		}
+
+		if r.URL.Path == "/favicon.ico" {
+			return
+		}
+
+		app.logger.Info(
+			"http request",
+			slog.String("request_id", requestID),
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", recorder.statusCode),
+			slog.Duration("duration", duration),
+			slog.String("remote_addr", r.RemoteAddr),
+		)
+	})
+}
+
+func requestRoute(r *http.Request) string {
+	routeContext := chi.RouteContext(r.Context())
+	if routeContext == nil {
+		return r.URL.Path
+	}
+
+	routePattern := routeContext.RoutePattern()
+	if routePattern != "" {
+		return routePattern
+	}
+
+	return r.URL.Path
+}
+
+func newRequestID() string {
+	var b [12]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return time.Now().UTC().Format("20060102150405.000000000")
+	}
+
+	return hex.EncodeToString(b[:])
+}
+
+type statusRecorder struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (r *statusRecorder) WriteHeader(statusCode int) {
+	r.statusCode = statusCode
+	r.ResponseWriter.WriteHeader(statusCode)
+}

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -9,6 +9,8 @@ import (
 
 func (app *application) routes() http.Handler {
 	router := chi.NewRouter()
+	router.Use(app.requestID)
+	router.Use(app.logRequest)
 	router.Use(app.recoverPanic)
 	router.Use(app.enableCORS)
 	router.Use(app.rateLimit)
@@ -20,6 +22,7 @@ func (app *application) routes() http.Handler {
 	router.MethodNotAllowed(app.methodNotAllowedResponse)
 
 	router.Get("/healthcheck", app.healthcheckHandler)
+	router.Get("/readyz", app.readinessHandler)
 
 	router.Get("/cities", app.listCitiesHandler)
 	router.Get("/countries", app.listCountriesHandler)

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -29,6 +29,43 @@ func TestHealthcheck(t *testing.T) {
 	assert.Equal(t, got["status"], "available")
 }
 
+func TestHealthcheckSetsRequestID(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, _ := ts.get(t, "/healthcheck")
+	assert.Equal(t, statusCode, http.StatusOK)
+	assert.Equal(t, header.Get("X-Request-ID") != "", true)
+}
+
+func TestHealthcheckEchoesIncomingRequestID(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, _ := ts.request(t, http.MethodGet, "/healthcheck", http.Header{
+		"X-Request-ID": []string{"req-12345"},
+	})
+	assert.Equal(t, statusCode, http.StatusOK)
+	assert.Equal(t, header.Get("X-Request-ID"), "req-12345")
+}
+
+func TestReadyz(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, body := ts.get(t, "/readyz")
+	assert.Equal(t, statusCode, http.StatusOK)
+	assert.Equal(t, header.Get("content-type"), "application/json")
+
+	var got envelope
+	unmarshalJSON(t, body, &got)
+	assert.Equal(t, got["status"], "ready")
+
+	checks, ok := got["checks"].(map[string]any)
+	assert.Equal(t, ok, true)
+	assert.Equal(t, checks["database"], "available")
+}
+
 // TestCities tests the “/cities” endpoint.
 func TestCities(t *testing.T) {
 	ts := newTestServer(testApp.routes())

--- a/cmd/api/testutils_test.go
+++ b/cmd/api/testutils_test.go
@@ -73,6 +73,7 @@ func newTestApplication(cfg config) (*application, *sql.DB, error) {
 	return &application{
 		config: cfg,
 		logger: logger,
+		db:     db,
 		models: data.NewModels(db),
 		mailer: mocks.NewMockMailer(),
 	}, db, nil
@@ -105,6 +106,37 @@ func (ts *testServer) get(t *testing.T, urlPath string) (int, http.Header, []byt
 			t.Errorf("failed to close response body: %v", err)
 		}
 	}()
+	body, err := io.ReadAll(rs.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return rs.StatusCode, rs.Header, bytes.TrimSpace(body)
+}
+
+func (ts *testServer) request(t *testing.T, method string, urlPath string, headers http.Header) (int, http.Header, []byte) {
+	req, err := http.NewRequest(method, ts.URL+urlPath, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for key, values := range headers {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+
+	rs, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if err := rs.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	}()
+
 	body, err := io.ReadAll(rs.Body)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary
Improves observability for the API with request IDs, structured access logging, a database-backed readiness endpoint, better error logging context, and lightweight expvar request metrics.

## Changes
- Added request ID middleware:
1. accepts incoming `X-Request-ID`
2. generates one if missing
3. stores it in request context
4. returns it in response headers
- Added structured HTTP access logging with `slog`:
1. `request_id`
2. `method`
3. `path`
4. `status`
5. `duration`
6. `remote_addr`
- Added `GET /readyz`:
1. checks DB availability with `PingContext`
2. returns project-style JSON response
- Improved server-side error logging:
1. includes `request_id`
2. includes `path`, `route`, and request URI
- Extended `expvar` with lightweight request metrics:
1. `total_requests`
2. `responses_2xx_total`
3. `responses_4xx_total`
4. `responses_5xx_total`
- Kept logging noise under control by skipping `/favicon.ico` in access logs.
- Added tests for:
1. `X-Request-ID` response behavior
2. incoming request ID echoing
3. `/readyz`

## Validation
- targeted observability tests pass
- full `make test` passes in local environment