### PR TITLE
fix(observability): refine API Grafana dashboard queries and panel naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ go.work.sum
 
 .code_examples/
 .envrc
+.venv/
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ run/api:
 run/api/auth:
 	@go run ./cmd/api -db-dsn=${RELOHELPER_DB_DSN} -auth-enabled=true
 
+## run/api/load: run the cmd/api application for load testing
+.PHONY: run/api/load
+run/api/load:
+	@go run ./cmd/api -db-dsn=${RELOHELPER_DB_DSN} -auth-enabled=false -limiter-enabled=false
+
 ## db/psql: connect to the database using psql
 .PHONY: db/psql
 db/psql:

--- a/monitoring/grafana/dashboards/relohelper-api-overview.json
+++ b/monitoring/grafana/dashboards/relohelper-api-overview.json
@@ -228,7 +228,7 @@
           "refId": "A"
         }
       ],
-      "title": "Global p95 Latency",
+      "title": "Global p95 Latency Last 5m",
       "type": "stat"
     },
     {
@@ -270,7 +270,7 @@
           "refId": "A"
         }
       ],
-      "title": "Rate Limiter Reject Ratio",
+      "title": "Rate Limiter Reject Ratio Last 5m",
       "type": "stat"
     },
     {
@@ -355,12 +355,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "sum by (route) (increase(relohelper_http_requests_total[$__range]))",
+          "expr": "topk(10, sum by (route) (increase(relohelper_http_requests_total[$__range])))",
           "legendFormat": "{{route}}",
-          "refId": "A"
+          "refId": "A",
+          "range": false,
+          "instant": true
         }
       ],
-      "title": "Total Requests by Route",
+      "title": "Top 10 Routes by Total Requests",
       "type": "bargauge"
     },
     {
@@ -404,7 +406,7 @@
           "refId": "A"
         }
       ],
-      "title": "Requests by Status Class",
+      "title": "Request Rate by Status Class",
       "type": "timeseries"
     },
     {
@@ -454,7 +456,7 @@
           "refId": "B"
         }
       ],
-      "title": "Rate Limiter Allowed vs Rejected",
+      "title": "Rate Limiter Allow/Reject Rate",
       "type": "timeseries"
     },
     {
@@ -537,18 +539,12 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "histogram_quantile(0.50, sum by (le, route) (rate(relohelper_http_request_duration_seconds_bucket[5m])))",
-          "legendFormat": "{{route}} p50",
-          "refId": "A"
-        },
-        {
-          "editorMode": "code",
-          "expr": "histogram_quantile(0.95, sum by (le, route) (rate(relohelper_http_request_duration_seconds_bucket[5m])))",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, route) (rate(relohelper_http_request_duration_seconds_bucket[5m]))))",
           "legendFormat": "{{route}} p95",
-          "refId": "B"
+          "refId": "A"
         }
       ],
-      "title": "Latency p50 and p95 by Route",
+      "title": "Top 10 Routes by p95 Latency Over Time",
       "type": "timeseries"
     },
     {
@@ -589,12 +585,14 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "topk(5, histogram_quantile(0.95, sum by (le, route) (rate(relohelper_http_request_duration_seconds_bucket[5m]))))",
+          "expr": "topk(10, histogram_quantile(0.95, sum by (le, route) (rate(relohelper_http_request_duration_seconds_bucket[5m]))))",
           "legendFormat": "{{route}}",
-          "refId": "A"
+          "refId": "A",
+          "range": false,
+          "instant": true
         }
       ],
-      "title": "Top Slow Routes (p95)",
+      "title": "Top 10 Slow Routes by p95 Latency",
       "type": "bargauge"
     }
   ],

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,8 @@
+{
+  "venvPath": ".",
+  "venv": ".venv",
+  "include": [
+    "tests/load"
+  ],
+  "typeCheckingMode": "standard"
+}

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,64 @@
+# Locust Load Tests
+
+These load tests exercise the main public city and country API routes using a realistic mix of list, detail, and batch requests.
+
+## Environment Setup
+
+Create and activate a virtual environment from the repository root:
+
+```bash
+uv venv .venv
+source .venv/bin/activate
+```
+
+Install dependencies:
+
+```bash
+uv pip install -r tests/load/requirements.txt
+```
+
+## Running Locust
+
+Start the API first in load-test mode, then run Locust from the repository root.
+
+For example:
+
+```bash
+make run/api/load
+```
+
+The load-test target disables:
+
+- authentication
+- rate limiting
+
+Web UI example:
+
+```bash
+locust -f tests/load/locustfile.py --host=http://127.0.0.1:4000
+```
+
+The Locust UI is available at `http://0.0.0.0:8089` by default.
+
+Headless example:
+
+```bash
+locust -f tests/load/locustfile.py --host=http://127.0.0.1:4000 --headless --users 20 --spawn-rate 5 --run-time 2m
+```
+
+## Base URL
+
+The load tests expect the API base URL to be provided via Locust `--host`, for example:
+
+```bash
+--host=http://127.0.0.1:4000
+```
+
+## Scenario Mix
+
+The test bootstrap fetches real data once at startup from:
+
+- `GET /countries`
+- `GET /cities`
+
+It then randomly selects valid `country_code` and `geoname_id` values for all subsequent requests.

--- a/tests/load/locustfile.py
+++ b/tests/load/locustfile.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import List
+
+import requests
+from locust import HttpUser, between, events, task
+
+CITY_HEAVY_INCLUDE = "numbeo_cost,numbeo_indices,avg_climate"
+COUNTRY_HEAVY_INCLUDE = "numbeo_indices,legatum_indices"
+
+CITY_BATCH_MIN = 2
+CITY_BATCH_MAX = 5
+COUNTRY_BATCH_MIN = 2
+COUNTRY_BATCH_MAX = 4
+BOOTSTRAP_TIMEOUT_SECONDS = 15
+
+
+@dataclass(frozen=True)
+class LoadTestData:
+    city_ids: List[int]
+    city_country_codes: List[str]
+    country_codes: List[str]
+
+
+@events.test_start.add_listener
+def bootstrap_api_data(environment, **_kwargs) -> None:
+    host = environment.host
+    if not host:
+        raise RuntimeError(
+            "Locust host is not set. Run with --host=http://127.0.0.1:4000 or set host in the UI."
+        )
+
+    session = requests.Session()
+
+    countries_response = session.get(
+        f"{host}/countries", timeout=BOOTSTRAP_TIMEOUT_SECONDS
+    )
+    countries_response.raise_for_status()
+    countries_payload = countries_response.json()
+    country_codes = [
+        country["country_code"] for country in countries_payload["countries"]
+    ]
+
+    cities_response = session.get(f"{host}/cities", timeout=BOOTSTRAP_TIMEOUT_SECONDS)
+    cities_response.raise_for_status()
+    cities_payload = cities_response.json()
+    cities = cities_payload["cities"]
+    city_ids = [city["geoname_id"] for city in cities]
+    city_country_codes = sorted({city["country_code"] for city in cities})
+
+    if not country_codes:
+        raise RuntimeError("Bootstrap failed: /countries returned no country codes")
+    if not city_ids:
+        raise RuntimeError("Bootstrap failed: /cities returned no city ids")
+    if not city_country_codes:
+        raise RuntimeError(
+            "Bootstrap failed: /cities returned no country codes with cities"
+        )
+
+    environment.relohelper_data = LoadTestData(
+        city_ids=city_ids,
+        city_country_codes=city_country_codes,
+        country_codes=country_codes,
+    )
+
+
+class RelohelperApiUser(HttpUser):
+    wait_time = between(1, 3)
+
+    @property
+    def data(self) -> LoadTestData:
+        data = getattr(self.environment, "relohelper_data", None)
+        if data is None:
+            raise RuntimeError("Load test data has not been initialized")
+        return data
+
+    def random_city_id(self) -> int:
+        return random.choice(self.data.city_ids)
+
+    def random_country_code(self) -> str:
+        return random.choice(self.data.country_codes)
+
+    def random_city_country_code(self) -> str:
+        return random.choice(self.data.city_country_codes)
+
+    def random_city_batch_ids(self) -> str:
+        batch_size = random.randint(CITY_BATCH_MIN, CITY_BATCH_MAX)
+        selected_ids = random.sample(self.data.city_ids, k=batch_size)
+        return ",".join(str(city_id) for city_id in selected_ids)
+
+    def random_country_batch_codes(self) -> str:
+        batch_size = random.randint(COUNTRY_BATCH_MIN, COUNTRY_BATCH_MAX)
+        selected_codes = random.sample(self.data.country_codes, k=batch_size)
+        return ",".join(selected_codes)
+
+    @task(15)
+    def cities_list_by_country_code(self) -> None:
+        self.client.get(
+            "/cities",
+            name="GET /cities?country_code",
+            params={"country_code": self.random_city_country_code()},
+        )
+
+    @task(15)
+    def cities_detail(self) -> None:
+        city_id = self.random_city_id()
+        self.client.get(f"/cities/{city_id}", name="GET /cities/{id}")
+
+    @task(20)
+    def cities_detail_with_heavy_include(self) -> None:
+        city_id = self.random_city_id()
+        self.client.get(
+            f"/cities/{city_id}",
+            name="GET /cities/{id}?include=heavy",
+            params={"include": CITY_HEAVY_INCLUDE},
+        )
+
+    @task(15)
+    def cities_batch(self) -> None:
+        self.client.get(
+            "/cities",
+            name="GET /cities?ids",
+            params={"ids": self.random_city_batch_ids()},
+        )
+
+    @task(20)
+    def cities_batch_with_heavy_include(self) -> None:
+        self.client.get(
+            "/cities",
+            name="GET /cities?ids&include=heavy",
+            params={
+                "ids": self.random_city_batch_ids(),
+                "include": CITY_HEAVY_INCLUDE,
+            },
+        )
+
+    @task(5)
+    def countries_detail(self) -> None:
+        country_code = self.random_country_code()
+        self.client.get(
+            f"/countries/{country_code}", name="GET /countries/{country_code}"
+        )
+
+    @task(5)
+    def countries_detail_with_heavy_include(self) -> None:
+        country_code = self.random_country_code()
+        self.client.get(
+            f"/countries/{country_code}",
+            name="GET /countries/{country_code}?include=heavy",
+            params={"include": COUNTRY_HEAVY_INCLUDE},
+        )
+
+    @task(5)
+    def countries_batch(self) -> None:
+        self.client.get(
+            "/countries",
+            name="GET /countries?country_codes",
+            params={"country_codes": self.random_country_batch_codes()},
+        )
+
+    @task(10)
+    def countries_batch_with_heavy_include(self) -> None:
+        self.client.get(
+            "/countries",
+            name="GET /countries?country_codes&include=heavy",
+            params={
+                "country_codes": self.random_country_batch_codes(),
+                "include": COUNTRY_HEAVY_INCLUDE,
+            },
+        )

--- a/tests/load/requirements.txt
+++ b/tests/load/requirements.txt
@@ -1,0 +1,2 @@
+locust
+requests


### PR DESCRIPTION
## Summary
Refines the API Grafana dashboard so top-route panels behave correctly and panel titles match the actual query semantics.

## Changes
- Updated top-route API panels to use `topk(...)` where appropriate.
- Fixed panel behavior so ranking panels work as true top-N views.
- Simplified latency visualization to focus on the most useful p95 route view.
- Cleaned up panel titles to match what the panels actually show:
1. fixed `Last 5m` summaries
2. top-10 ranking panels
3. rate-based panels

## Validation
- dashboard JSON validated successfully
- panel naming and PromQL reviewed against actual dashboard behavior