### PR TITLE
feat(release): prepare v0.2.0 VPS deployment with Caddy, Docker Compose, and monitoring access

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ See [deploy/DEPLOY.md](./deploy/DEPLOY.md) for:
 - public and internal service exposure
 - secure Grafana access via SSH tunnel
 
+Run the VPS stack from the repository root with:
+
+```bash
+docker compose --env-file .env -f deploy/docker-compose.yml up -d --build
+```
+
 ## Recommendation by Use Case
 
 - Local development:

--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -56,7 +56,7 @@ Fill in at least:
 From the repository root:
 
 ```bash
-docker compose -f deploy/docker-compose.yml up -d --build
+docker compose --env-file .env -f deploy/docker-compose.yml up -d --build
 ```
 
 ## Public URLs
@@ -120,6 +120,18 @@ ssh -L 3000:localhost:3000 <user>@<your_vps_ip>
 Then open locally in your browser:
 
 - `http://127.0.0.1:3000`
+
+## Notes
+
+- Because the deploy compose file lives in `deploy/`, start it with `--env-file .env` from the repository root so Compose picks up the root `.env`.
+- This deploy stack uses the PostgreSQL 18 container layout and mounts the data volume at `/var/lib/postgresql`.
+- If you need to change API runtime flags for VPS deploy, edit the `api.command` section in `deploy/docker-compose.yml`, then apply the change with:
+
+```bash
+docker compose --env-file .env -f deploy/docker-compose.yml up -d
+```
+
+Compose will usually recreate only the `api` container when only its command changes. PostgreSQL, Prometheus, Grafana, and Caddy are not rebuilt or restarted unless their own configuration changes.
 
 ## Local development remains unchanged
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
@@ -63,12 +63,7 @@ services:
       RELOHELPER_SMTP_USERNAME: ${RELOHELPER_SMTP_USERNAME:-}
       RELOHELPER_SMTP_PASSWORD: ${RELOHELPER_SMTP_PASSWORD:-}
       RELOHELPER_SMTP_SENDER: ${RELOHELPER_SMTP_SENDER:-Relohelper <no-reply@relohelper.local>}
-    command:
-      [
-        "/app/api",
-        "-env=production",
-        "-metrics-port=4001",
-      ]
+    command: ["/app/api", "-env=production", "-metrics-port=4001"]
     expose:
       - "4000"
       - "4001"

--- a/migrations/000001_create_users_table.up.sql
+++ b/migrations/000001_create_users_table.up.sql
@@ -1,3 +1,5 @@
+CREATE EXTENSION IF NOT EXISTS citext;
+
 CREATE TABLE IF NOT EXISTS users (
     id bigserial PRIMARY KEY,
     created_at timestamp(0) with time zone NOT NULL DEFAULT NOW(),


### PR DESCRIPTION
## Summary
Prepares the project for a production-like VPS deployment as part of the `v0.2.0` release. The API can now be deployed behind Caddy with automatic HTTPS, Prometheus remains internal-only, Grafana is accessible securely through SSH tunneling, and the local development workflow stays unchanged.

## Changes
- Added a dedicated VPS deploy stack:
  - `deploy/docker-compose.yml`
  - `deploy/Caddyfile`
  - `deploy/DEPLOY.md`
- Kept the API public over `https://relohelper.pro` behind Caddy.
- Kept internal services private by default:
  - PostgreSQL not published
  - Prometheus not published
  - `/metrics` not publicly exposed
- Kept Grafana non-public and bound only to VPS loopback:
  - `127.0.0.1:3000:3000`
  - intended for SSH tunnel access
- Updated the API image setup:
  - multi-stage `Dockerfile`
  - compiled Go binary in final container
- Fixed VPS deployment issues discovered during first real deploy:
  - explicit `--env-file .env` usage
  - PostgreSQL 18 volume mount path
  - `citext` extension creation in initial migration
- Simplified deployment modes:
  - local development uses `go run` plus `monitoring/docker-compose.yml`
  - removed the unused root full-stack compose file
- Kept Swagger publicly available while keeping `/debug/vars` disabled in production.
- Cleaned up deploy documentation to make `deploy/DEPLOY.md` the single detailed source of truth.

## Validation
- `docker compose --env-file .env -f deploy/docker-compose.yml config` validates successfully
- VPS deploy was exercised against a real Ubuntu server
- startup issues with PostgreSQL and migrations were fixed and verified during deployment