### PR TITLE
fix(observability): collapse unmatched API paths into a single Prometheus route label

### DIFF
--- a/cmd/api/observability.go
+++ b/cmd/api/observability.go
@@ -225,7 +225,7 @@ func (app *application) collectPrometheusMetrics(next http.Handler) http.Handler
 func requestRoute(r *http.Request) string {
 	routeContext := chi.RouteContext(r.Context())
 	if routeContext == nil {
-		return r.URL.Path
+		return "unmatched"
 	}
 
 	routePattern := routeContext.RoutePattern()
@@ -233,7 +233,7 @@ func requestRoute(r *http.Request) string {
 		return routePattern
 	}
 
-	return r.URL.Path
+	return "unmatched"
 }
 
 func newRequestID() string {

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -116,6 +116,34 @@ func TestMetricsHiddenOnMainRouterWhenDedicatedMetricsPortConfigured(t *testing.
 	assert.Equal(t, statusCode, http.StatusNotFound)
 }
 
+func TestMetricsCollapseUnmatchedRoutes(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	_, _, _ = ts.get(t, "/wp-admin")
+	_, _, _ = ts.get(t, "/totally-random-path")
+
+	rs, err := ts.Client().Get(ts.URL + "/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := rs.Body.Close(); err != nil {
+			t.Errorf("failed to close response body: %v", err)
+		}
+	}()
+
+	body, err := io.ReadAll(rs.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	metrics := string(body)
+	assert.Equal(t, strings.Contains(metrics, `route="unmatched"`), true)
+	assert.Equal(t, strings.Contains(metrics, `route="/wp-admin"`), false)
+	assert.Equal(t, strings.Contains(metrics, `route="/totally-random-path"`), false)
+}
+
 func TestSwaggerAvailableOnMainRouter(t *testing.T) {
 	ts := newTestServer(testApp.routes())
 	defer ts.Close()


### PR DESCRIPTION
## Summary
Prevents random public internet probes and invalid paths from polluting API Prometheus metrics with high-cardinality route labels.

## Changes
- Updated HTTP metrics labeling so unmatched requests no longer use the raw request path as the `route` label.
- Unmatched requests are now grouped under a single stable label:
  - `route="unmatched"`
- Added a test to verify that unknown paths are aggregated instead of creating separate Prometheus series.

## Why
After exposing the API on a public domain, random bot and scanner traffic started hitting many non-existent paths. Returning `404` is correct, but using raw unmatched paths in Prometheus metrics created unnecessary label cardinality and made Grafana noisier than it should be.

## Result
- Valid application routes still appear normally in Grafana
- Invalid/random paths are aggregated into one bucket
- API metrics stay cleaner and more production-friendly