### PR TITLE
fix(monitoring): make DB pool runtime panels more informative

### DIFF
--- a/monitoring/grafana/dashboards/relohelper-go-runtime.json
+++ b/monitoring/grafana/dashboards/relohelper-go-runtime.json
@@ -43,9 +43,7 @@
         "justifyMode": "center",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -85,9 +83,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -127,9 +123,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -169,9 +163,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -211,9 +203,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -222,11 +212,11 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "relohelper_db_in_use_connections",
+          "expr": "sum(increase(relohelper_db_wait_count_total[5m])) or vector(0)",
           "refId": "A"
         }
       ],
-      "title": "DB Pool In Use",
+      "title": "DB Pool Waits (Last 5m)",
       "type": "stat"
     },
     {
@@ -253,9 +243,7 @@
         "justifyMode": "auto",
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -557,24 +545,18 @@
         },
         {
           "editorMode": "code",
-          "expr": "relohelper_db_in_use_connections",
-          "legendFormat": "in use",
-          "refId": "B"
-        },
-        {
-          "editorMode": "code",
           "expr": "relohelper_db_idle_connections",
           "legendFormat": "idle",
-          "refId": "C"
+          "refId": "B"
         },
         {
           "editorMode": "code",
           "expr": "relohelper_db_max_open_connections",
           "legendFormat": "max open",
-          "refId": "D"
+          "refId": "C"
         }
       ],
-      "title": "DB Pool Connections",
+      "title": "DB Pool Open / Idle / Max Connections",
       "type": "timeseries"
     },
     {
@@ -668,13 +650,7 @@
   ],
   "refresh": "10s",
   "schemaVersion": 41,
-  "tags": [
-    "relohelper",
-    "go",
-    "runtime",
-    "observability",
-    "saturation"
-  ],
+  "tags": ["relohelper", "go", "runtime", "observability", "saturation"],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
## Summary
Improves the DB pool section of the Go runtime Grafana dashboard so it reflects real pool pressure more clearly and avoids misleading snapshot-only signals.

## Changes
- Replaced the `DB Pool In Use` stat panel with:
  - `DB Pool Waits (Last 5m)`
- Updated the new stat panel to show a single aggregated value:
  - `sum(increase(relohelper_db_wait_count_total[5m])) or vector(0)`
- Simplified the DB connections time-series panel:
  - removed the low-signal `in use` series
  - kept `open`, `idle`, and `max open`
- Renamed the connections panel to:
  - `DB Pool Open / Idle / Max Connections`
- Aligned the stat panel naming with the rest of the runtime dashboard style.

## Why
`DB Pool In Use` as a top-row stat was too snapshot-dependent for this workload and often looked random because DB usage bursts are shorter than the scrape interval. The updated panel focuses on a more meaningful signal: whether requests actually had to wait for a DB connection in the last 5 minutes.

## Result
- the top DB stat is now more actionable
- the DB block is easier to interpret during load testing
- the runtime dashboard better reflects actual DB pool pressure rather than random scrape timing