### PR TITLE
chore(deploy): add Prometheus retention limits and Docker log rotation

### DIFF
--- a/deploy/DEPLOY.md
+++ b/deploy/DEPLOY.md
@@ -130,6 +130,12 @@ Then open locally in your browser:
 
 - Because the deploy compose file lives in `deploy/`, start it with `--env-file .env` from the repository root so Compose picks up the root `.env`.
 - This deploy stack uses the PostgreSQL 18 container layout and mounts the data volume at `/var/lib/postgresql`.
+- Docker container logs are rotated with:
+  - `max-size=10m`
+  - `max-file=5`
+- Prometheus retention is limited to:
+  - `7d`
+  - `1GB`
 - API runtime toggles for VPS deploy are controlled from `.env` and injected into the container command by Docker Compose:
   - `RELOHELPER_DB_MAX_OPEN_CONNS`
   - `RELOHELPER_LIMITER_RPS`

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -2,6 +2,11 @@ services:
   caddy:
     image: caddy:2.10
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     depends_on:
       api:
         condition: service_started
@@ -16,6 +21,11 @@ services:
   postgres:
     image: postgres:18
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     environment:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
@@ -32,6 +42,11 @@ services:
   migrate:
     image: migrate/migrate:v4.19.1
     restart: "no"
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     depends_on:
       postgres:
         condition: service_healthy
@@ -51,6 +66,11 @@ services:
       context: ..
       dockerfile: Dockerfile
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     depends_on:
       postgres:
         condition: service_healthy
@@ -81,12 +101,19 @@ services:
   prometheus:
     image: prom/prometheus:v3.10.0
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     depends_on:
       api:
         condition: service_started
     command:
       - --config.file=/etc/prometheus/prometheus.yml
       - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=7d
+      - --storage.tsdb.retention.size=1GB
     volumes:
       - ../monitoring/prometheus/prometheus.compose.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
@@ -94,6 +121,11 @@ services:
   grafana:
     image: grafana/grafana:12.4
     restart: unless-stopped
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     depends_on:
       prometheus:
         condition: service_started


### PR DESCRIPTION
## Summary
Hardens the VPS deploy stack against gradual disk growth by limiting Prometheus storage retention and enabling Docker log rotation for all deployed services.

## Changes
- Added Docker log rotation to the VPS deploy stack for:
  - `caddy`
  - `postgres`
  - `migrate`
  - `api`
  - `prometheus`
  - `grafana`
- Configured log rotation with:
  - `max-size: 10m`
  - `max-file: 5`
- Added Prometheus TSDB retention limits:
  - `--storage.tsdb.retention.time=7d`
  - `--storage.tsdb.retention.size=1GB`
- Updated deploy documentation to explain the configured limits and their purpose.

## Why
The VPS runs continuously and is updated repeatedly through Docker Compose rebuilds. Without retention and log limits, Prometheus data and Docker container logs can gradually consume disk space and eventually affect server stability.

## Result
- Prometheus storage is now bounded
- container logs no longer grow without limit
- the VPS deploy setup is safer for long-running operation