### PR TITLE
Add first dashboard UI for city comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ go.work.sum
 .envrc
 .venv/
 __pycache__
+
+.workspace/

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Relohelper is a REST API service rewritten in Go as a high-performance successor
 
 The Go implementation is now the primary and actively developed version of the project.
 
+Starting from [`v0.3.0`](https://github.com/denis-k2/relohelper-go/releases/tag/v0.3.0), the project also includes a built-in dashboard UI on top of the API. The UI is intended as a reference client for comparing cities by cost of living, climate, and quality of life, while the API remains the core product surface.
+
 ## About the Project
 
 This project focuses on:
@@ -12,6 +14,7 @@ This project focuses on:
 - Structured architecture
 - Performance-oriented implementation
 - Reproducible load testing
+- A reference dashboard UI built on top of the API
 
 The original Python implementation can be found [here](https://github.com/denis-k2/relohelper).
 
@@ -23,6 +26,13 @@ Project documentation is located in the `docs/` directory:
 - `docs/performance/` — load testing methodology and benchmark runs
 
 Performance comparison between Go and Python implementations is documented [here](./docs/performance/runs/2025-04-22_compare-go-v0.1.0_py-v0.3.0/README.md).
+
+## Public Access
+
+- Dashboard UI: `https://relohelper.pro/`
+- Swagger UI: `https://relohelper.pro/swagger`
+- `/metrics` is internal-only
+- Grafana is available through SSH tunneling only
 
 ## Local Development
 

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -23,6 +23,9 @@ func (app *application) routes() http.Handler {
 	router.NotFound(app.notFoundResponse)
 	router.MethodNotAllowed(app.methodNotAllowedResponse)
 
+	router.Get("/", app.dashboardHandler)
+	router.Get("/app.js", app.dashboardAppJSHandler)
+	router.Get("/styles.css", app.dashboardStylesHandler)
 	router.Get("/healthcheck", app.healthcheckHandler)
 	router.Get("/readyz", app.readinessHandler)
 	if app.config.metrics.port == 0 {

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -26,6 +26,7 @@ func (app *application) routes() http.Handler {
 	router.Get("/", app.dashboardHandler)
 	router.Get("/app.js", app.dashboardAppJSHandler)
 	router.Get("/styles.css", app.dashboardStylesHandler)
+	router.Get("/favicon.svg", app.dashboardFaviconHandler)
 	router.Get("/healthcheck", app.healthcheckHandler)
 	router.Get("/readyz", app.readinessHandler)
 	if app.config.metrics.port == 0 {

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -25,6 +25,9 @@ func (app *application) routes() http.Handler {
 
 	router.Get("/", app.dashboardHandler)
 	router.Get("/app.js", app.dashboardAppJSHandler)
+	router.Get("/helpers.js", app.dashboardHelpersJSHandler)
+	router.Get("/tooltips.js", app.dashboardTooltipsJSHandler)
+	router.Get("/climate.js", app.dashboardClimateJSHandler)
 	router.Get("/styles.css", app.dashboardStylesHandler)
 	router.Get("/favicon.svg", app.dashboardFaviconHandler)
 	router.Get("/healthcheck", app.healthcheckHandler)

--- a/cmd/api/routes_test.go
+++ b/cmd/api/routes_test.go
@@ -197,6 +197,31 @@ func TestSwaggerAvailableOnMainRouter(t *testing.T) {
 	assert.Equal(t, header.Get("content-type"), "text/html; charset=utf-8")
 }
 
+func TestDashboardAvailableOnRoot(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, body := ts.get(t, "/")
+	assert.Equal(t, statusCode, http.StatusOK)
+	assert.Equal(t, strings.Contains(header.Get("content-type"), "text/html"), true)
+	assert.Equal(t, strings.Contains(string(body), "Relohelper Dashboard"), true)
+}
+
+func TestDashboardStaticAssetsAvailable(t *testing.T) {
+	ts := newTestServer(testApp.routes())
+	defer ts.Close()
+
+	statusCode, header, body := ts.get(t, "/app.js")
+	assert.Equal(t, statusCode, http.StatusOK)
+	assert.Equal(t, strings.Contains(header.Get("content-type"), "javascript"), true)
+	assert.Equal(t, strings.Contains(string(body), "const state ="), true)
+
+	statusCode, header, body = ts.get(t, "/styles.css")
+	assert.Equal(t, statusCode, http.StatusOK)
+	assert.Equal(t, strings.Contains(header.Get("content-type"), "text/css"), true)
+	assert.Equal(t, strings.Contains(string(body), ":root"), true)
+}
+
 func TestSwaggerAvailableInProductionWhileDebugVarsStayDisabled(t *testing.T) {
 	appWithProductionEnv := &application{
 		config: testApp.config,

--- a/cmd/api/swagger.go
+++ b/cmd/api/swagger.go
@@ -14,6 +14,7 @@ const swaggerHTML = `<!doctype html>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Relohelper API Docs</title>
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg">
   <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
 </head>
 <body>

--- a/cmd/api/ui.go
+++ b/cmd/api/ui.go
@@ -25,6 +25,18 @@ func (app *application) dashboardAppJSHandler(w http.ResponseWriter, r *http.Req
 	app.serveUIAsset(w, r, "app.js", "application/javascript; charset=utf-8")
 }
 
+func (app *application) dashboardHelpersJSHandler(w http.ResponseWriter, r *http.Request) {
+	app.serveUIAsset(w, r, "helpers.js", "application/javascript; charset=utf-8")
+}
+
+func (app *application) dashboardTooltipsJSHandler(w http.ResponseWriter, r *http.Request) {
+	app.serveUIAsset(w, r, "tooltips.js", "application/javascript; charset=utf-8")
+}
+
+func (app *application) dashboardClimateJSHandler(w http.ResponseWriter, r *http.Request) {
+	app.serveUIAsset(w, r, "climate.js", "application/javascript; charset=utf-8")
+}
+
 func (app *application) dashboardStylesHandler(w http.ResponseWriter, r *http.Request) {
 	app.serveUIAsset(w, r, "styles.css", "text/css; charset=utf-8")
 }

--- a/cmd/api/ui.go
+++ b/cmd/api/ui.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"net/http"
+
+	uiassets "github.com/denis-k2/relohelper-go/ui"
+)
+
+func (app *application) serveUIAsset(w http.ResponseWriter, r *http.Request, path string, contentType string) {
+	asset, err := uiassets.ReadFile(path)
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	_, _ = w.Write(asset)
+}
+
+func (app *application) dashboardHandler(w http.ResponseWriter, r *http.Request) {
+	app.serveUIAsset(w, r, "index.html", "text/html; charset=utf-8")
+}
+
+func (app *application) dashboardAppJSHandler(w http.ResponseWriter, r *http.Request) {
+	app.serveUIAsset(w, r, "app.js", "application/javascript; charset=utf-8")
+}
+
+func (app *application) dashboardStylesHandler(w http.ResponseWriter, r *http.Request) {
+	app.serveUIAsset(w, r, "styles.css", "text/css; charset=utf-8")
+}

--- a/cmd/api/ui.go
+++ b/cmd/api/ui.go
@@ -28,3 +28,7 @@ func (app *application) dashboardAppJSHandler(w http.ResponseWriter, r *http.Req
 func (app *application) dashboardStylesHandler(w http.ResponseWriter, r *http.Request) {
 	app.serveUIAsset(w, r, "styles.css", "text/css; charset=utf-8")
 }
+
+func (app *application) dashboardFaviconHandler(w http.ResponseWriter, r *http.Request) {
+	app.serveUIAsset(w, r, "favicon.svg", "image/svg+xml")
+}

--- a/ui/app.js
+++ b/ui/app.js
@@ -287,6 +287,7 @@ function renderSelectedCountries() {
         renderCountries();
         renderSelectedCountries();
         filterCitiesForSelectedCountries();
+        applyLoadedComparisonSelection();
       });
     });
 }
@@ -332,6 +333,7 @@ function renderSelectedCities() {
         renderCities();
         renderSelectedCities();
         updateMetrics();
+        applyLoadedComparisonSelection();
       });
     });
 }
@@ -717,11 +719,15 @@ function resetDashboard() {
 
 function collapseFilters() {
   els.filtersCard.classList.add("is-collapsed");
+  els.compareBtn.classList.add("hidden");
+  els.resetBtn.classList.add("hidden");
   els.editFiltersBtn.classList.remove("hidden");
 }
 
 function expandFilters() {
   els.filtersCard.classList.remove("is-collapsed");
+  els.compareBtn.classList.remove("hidden");
+  els.resetBtn.classList.remove("hidden");
   els.editFiltersBtn.classList.add("hidden");
 }
 
@@ -775,6 +781,27 @@ function applyBreakdownSort(param) {
   state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
 
   renderCostBreakdownTable();
+}
+
+function applyLoadedComparisonSelection() {
+  if (!state.comparisonData.length) return;
+
+  const selectedIDs = new Set(Array.from(state.selectedCityIds));
+  state.comparisonData = state.comparisonData.filter((city) =>
+    selectedIDs.has(String(city.geoname_id ?? city.city_id ?? city.id ?? "")),
+  );
+
+  if (state.comparisonData.length === 0) {
+    state.costBreakdownData = [];
+    state.breakdownSort = null;
+    renderCostBreakdownTable();
+    renderClimateChart();
+    return;
+  }
+
+  state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
+  renderCostBreakdownTable();
+  renderClimateChart();
 }
 
 function sortComparisonDataByCostParam(param, direction) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -5,6 +5,8 @@ const state = {
   selectedCountryCodes: new Set(),
   selectedCityIds: new Set(),
   comparisonData: [],
+  costBreakdownData: [],
+  collapsedCostCategories: new Set(),
   climateChart: null,
 };
 
@@ -24,6 +26,10 @@ const els = {
   chartEmptyState: document.getElementById("chartEmptyState"),
   comparisonTableWrapper: document.getElementById("comparisonTableWrapper"),
   comparisonTableBody: document.querySelector("#comparisonTable tbody"),
+  costBreakdownEmptyState: document.getElementById("costBreakdownEmptyState"),
+  costBreakdownWrapper: document.getElementById("costBreakdownWrapper"),
+  costBreakdownHeadRow: document.getElementById("costBreakdownHeadRow"),
+  costBreakdownBody: document.getElementById("costBreakdownBody"),
   metricCities: document.getElementById("metricCities"),
   metricCountries: document.getElementById("metricCountries"),
   metricLowestRent: document.getElementById("metricLowestRent"),
@@ -297,8 +303,10 @@ async function loadComparison() {
       : Array.isArray(data.data)
         ? data.data
         : [];
+    state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
 
     renderComparisonTable();
+    renderCostBreakdownTable();
     renderClimateChart();
     updateMetrics();
     collapseFilters();
@@ -417,6 +425,208 @@ function renderClimateChart() {
   });
 }
 
+function renderCostBreakdownTable() {
+  if (!state.costBreakdownData.length || !state.comparisonData.length) {
+    els.costBreakdownEmptyState.classList.remove("hidden");
+    els.costBreakdownWrapper.classList.add("hidden");
+    return;
+  }
+
+  els.costBreakdownEmptyState.classList.add("hidden");
+  els.costBreakdownWrapper.classList.remove("hidden");
+
+  els.costBreakdownHeadRow.innerHTML = `
+    <th>Item</th>
+    ${state.comparisonData
+      .map((city) => {
+        const cityName = city.city ?? city.name ?? "City";
+        const country = city.country_code ?? city.country ?? "";
+        return `<th>${escapeHtml(cityName)}<br><span class="selection-subtitle">${escapeHtml(String(country))}</span></th>`;
+      })
+      .join("")}
+  `;
+
+  els.costBreakdownBody.innerHTML = state.costBreakdownData
+    .map((group) => {
+      const isCollapsed = state.collapsedCostCategories.has(group.category);
+      const groupRows = group.items
+        .map((item) => {
+          const isSalaryRow =
+            item.param === "Average Monthly Net Salary (After Tax)";
+          const isMortgageRateRow =
+            item.param === "Annual Mortgage Interest Rate (20-Year Fixed, in %)";
+          const numericEntries = item.values
+            .map((value, index) => ({
+              index,
+              numericValue: toNumber(value?.cost),
+            }))
+            .filter((entry) => entry.numericValue != null);
+          const numericValues = numericEntries.map((entry) => entry.numericValue);
+          const minValue =
+            numericValues.length > 0 ? Math.min(...numericValues) : null;
+          const maxValue =
+            numericValues.length > 0 ? Math.max(...numericValues) : null;
+          const shouldApplySecondary =
+            item.values.length - numericValues.length <= 1 && numericValues.length >= 3;
+          const sortedUniqueValues = shouldApplySecondary
+            ? Array.from(new Set(numericValues)).sort((a, b) => a - b)
+            : [];
+          const secondMinValue =
+            sortedUniqueValues.length >= 3 ? sortedUniqueValues[1] : null;
+          const secondMaxValue =
+            sortedUniqueValues.length >= 3
+              ? sortedUniqueValues[sortedUniqueValues.length - 2]
+              : null;
+          const cells = item.values
+            .map((value) => {
+              const numericValue = toNumber(value?.cost);
+              let cellClass = "cost-value";
+
+              if (numericValue != null && minValue != null && maxValue != null && minValue !== maxValue) {
+                if (isSalaryRow) {
+                  if (numericValue === minValue) {
+                    cellClass += " cost-value-high";
+                  } else if (numericValue === maxValue) {
+                    cellClass += " cost-value-low";
+                  } else if (shouldApplySecondary && secondMinValue != null && numericValue === secondMinValue) {
+                    cellClass += " cost-value-high-soft";
+                  } else if (shouldApplySecondary && secondMaxValue != null && numericValue === secondMaxValue) {
+                    cellClass += " cost-value-low-soft";
+                  }
+                } else if (numericValue === minValue) {
+                  cellClass += " cost-value-low";
+                } else if (numericValue === maxValue) {
+                  cellClass += " cost-value-high";
+                } else if (shouldApplySecondary && secondMinValue != null && numericValue === secondMinValue) {
+                  cellClass += " cost-value-low-soft";
+                } else if (shouldApplySecondary && secondMaxValue != null && numericValue === secondMaxValue) {
+                  cellClass += " cost-value-high-soft";
+                }
+              }
+
+              return `<td class="${cellClass}">${escapeHtml(formatCostValue(value, { isMortgageRate: isMortgageRateRow }))}</td>`;
+            })
+            .join("");
+
+          return `
+            <tr ${isCollapsed ? 'class="hidden"' : ""}>
+              <td class="cost-item-name">${escapeHtml(item.param)}</td>
+              ${cells}
+            </tr>
+          `;
+        })
+        .join("");
+
+      return `
+        <tr class="cost-group-row ${isCollapsed ? "is-collapsed" : ""}">
+          <td class="cost-group-cell cost-group-cell-main">
+            <button class="cost-group-toggle" type="button" data-cost-group="${escapeHtml(group.category)}" aria-expanded="${isCollapsed ? "false" : "true"}">
+              <span class="cost-group-label">
+                <span class="cost-group-arrow">▾</span>
+                <span>${escapeHtml(group.category)}</span>
+              </span>
+            </button>
+          </td>
+          <td class="cost-group-cell cost-group-cell-fill" colspan="${state.comparisonData.length}">
+            <span class="cost-group-count">${group.items.length} items</span>
+          </td>
+        </tr>
+        ${groupRows}
+      `;
+    })
+    .join("");
+
+  els.costBreakdownBody
+    .querySelectorAll("[data-cost-group]")
+    .forEach((button) => {
+      button.addEventListener("click", () => {
+        const category = button.dataset.costGroup;
+        if (!category) return;
+
+        if (state.collapsedCostCategories.has(category)) {
+          state.collapsedCostCategories.delete(category);
+        } else {
+          state.collapsedCostCategories.add(category);
+        }
+
+        renderCostBreakdownTable();
+      });
+    });
+}
+
+function buildCostBreakdownDataset(cities) {
+  if (!cities.length) return [];
+
+  const preferredCategoryOrder = [
+    "Summary",
+    "Rent Per Month",
+    "Markets",
+    "Restaurants",
+    "Transportation",
+    "Utilities (Monthly)",
+    "Sports And Leisure",
+    "Childcare",
+    "Clothing And Shoes",
+    "Buy Apartment Price",
+    "Salaries And Financing",
+  ];
+  const categories = new Map();
+
+  for (const city of cities) {
+    const prices = city.numbeo_cost?.prices;
+    if (!Array.isArray(prices)) continue;
+
+    for (const price of prices) {
+      if (!price?.category || !price?.param) continue;
+
+      if (!categories.has(price.category)) {
+        categories.set(price.category, new Map());
+      }
+
+      const categoryItems = categories.get(price.category);
+      if (!categoryItems.has(price.param)) {
+        categoryItems.set(price.param, true);
+      }
+    }
+  }
+
+  const sortedCategories = Array.from(categories.keys()).sort((a, b) => {
+    const aIndex = preferredCategoryOrder.indexOf(a);
+    const bIndex = preferredCategoryOrder.indexOf(b);
+    if (aIndex === -1 && bIndex === -1) return a.localeCompare(b);
+    if (aIndex === -1) return 1;
+    if (bIndex === -1) return -1;
+    return aIndex - bIndex;
+  });
+
+  return sortedCategories.map((category) => {
+    const params = Array.from(categories.get(category).keys());
+
+    return {
+      category,
+      items: params.map((param) => ({
+        param,
+        values: cities.map((city) => {
+          const prices = city.numbeo_cost?.prices;
+          const currency = city.numbeo_cost?.currency ?? "USD";
+          if (!Array.isArray(prices)) {
+            return { cost: null, currency };
+          }
+
+          const entry = prices.find(
+            (price) => price.category === category && price.param === param,
+          );
+
+          return {
+            cost: entry?.cost ?? null,
+            currency,
+          };
+        }),
+      })),
+    };
+  });
+}
+
 function updateMetrics() {
   els.metricCities.textContent = String(state.selectedCityIds.size);
   els.metricCountries.textContent = String(state.selectedCountryCodes.size);
@@ -468,6 +678,8 @@ function resetDashboard() {
   state.selectedCityIds.clear();
   state.cities = [];
   state.comparisonData = [];
+  state.costBreakdownData = [];
+  state.collapsedCostCategories.clear();
 
   els.countrySearch.value = "";
   els.citySearch.value = "";
@@ -477,6 +689,7 @@ function resetDashboard() {
   renderSelectedCountries();
   renderSelectedCities();
   renderComparisonTable();
+  renderCostBreakdownTable();
 
   els.chartEmptyState.classList.remove("hidden");
   if (state.climateChart) {
@@ -515,6 +728,24 @@ function toNumber(value) {
 function fmt(value) {
   const n = toNumber(value);
   return n == null ? "—" : n.toFixed(1);
+}
+
+function formatCostValue(value, options = {}) {
+  if (!value) return "—";
+  const n = toNumber(value.cost);
+  if (n == null) return "—";
+
+  if (options.isMortgageRate) {
+    return `${n.toFixed(2)}%`;
+  }
+
+  const fractionDigits = n >= 100 ? 0 : 2;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: value.currency ?? "USD",
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
+  }).format(n);
 }
 
 function escapeHtml(value) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -5,10 +5,12 @@ const state = {
   selectedCountryCodes: new Set(),
   selectedCityIds: new Set(),
   comparisonData: [],
+  countryComparisonData: [],
   costBreakdownData: [],
   collapsedCostCategories: new Set(),
   breakdownSort: null,
   indicesSort: null,
+  countryIndicesSort: null,
   climateCharts: [],
   climateHiddenCities: new Set(),
   climateHoveredCityKey: null,
@@ -48,6 +50,11 @@ const numbeoIndexRows = [
   { key: "pollution", label: "Pollution", better: "low" },
 ];
 
+const countryNumbeoIndexRows = [
+  ...numbeoIndexRows,
+  { key: "avg_salary_usd", label: "Average Salary (USD)", better: "high", format: "currency" },
+];
+
 const els = {
   filtersCard: document.querySelector(".filters-card"),
   filtersBody: document.getElementById("filtersBody"),
@@ -73,6 +80,10 @@ const els = {
   numbeoIndicesWrapper: document.getElementById("numbeoIndicesWrapper"),
   numbeoIndicesHeadRow: document.getElementById("numbeoIndicesHeadRow"),
   numbeoIndicesBody: document.getElementById("numbeoIndicesBody"),
+  countryNumbeoIndicesEmptyState: document.getElementById("countryNumbeoIndicesEmptyState"),
+  countryNumbeoIndicesWrapper: document.getElementById("countryNumbeoIndicesWrapper"),
+  countryNumbeoIndicesHeadRow: document.getElementById("countryNumbeoIndicesHeadRow"),
+  countryNumbeoIndicesBody: document.getElementById("countryNumbeoIndicesBody"),
   climateTemperatureCanvas: document.getElementById("climateTemperatureChart"),
   climateSunshineCanvas: document.getElementById("climateSunshineChart"),
   climateDaylightCanvas: document.getElementById("climateDaylightChart"),
@@ -409,14 +420,18 @@ async function loadComparison() {
       : Array.isArray(data.data)
         ? data.data
         : [];
+    state.countryComparisonData = await loadCountryComparisonData(state.comparisonData);
     state.breakdownSort = null;
     state.climateHiddenCities.clear();
     state.climateHoveredCityKey = null;
+    state.indicesSort = null;
+    state.countryIndicesSort = null;
     state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
 
     renderCostBreakdownTable();
     renderClimateChart();
     renderNumbeoIndicesTable();
+    renderCountryNumbeoIndicesTable();
     updateMetrics();
     collapseFilters();
   } catch (error) {
@@ -771,37 +786,97 @@ function renderCostBreakdownTable() {
 }
 
 function renderNumbeoIndicesTable() {
-  if (!state.comparisonData.length) {
-    els.numbeoIndicesEmptyState.classList.remove("hidden");
-    els.numbeoIndicesWrapper.classList.add("hidden");
+  renderNumbeoIndicesTableSection({
+    data: state.comparisonData,
+    emptyStateEl: els.numbeoIndicesEmptyState,
+    wrapperEl: els.numbeoIndicesWrapper,
+    headRowEl: els.numbeoIndicesHeadRow,
+    bodyEl: els.numbeoIndicesBody,
+    headLabel: "Index",
+    rows: numbeoIndexRows,
+    sortState: state.indicesSort,
+    keyDataAttr: "data-index-key",
+    applySort: applyIndicesSort,
+    getColumnLabel: (city) => city.city ?? city.name ?? "City",
+    getColumnMeta: (city) =>
+      getDisplayCountryName(
+        city.country ?? city.country_name ?? city.country_code ?? "",
+      ),
+    getColumnMetaTitle: (city) =>
+      city.country ?? city.country_name ?? city.country_code ?? "",
+    getValue: (city, key) => toNumber(city.numbeo_indices?.[key]),
+  });
+}
+
+function renderCountryNumbeoIndicesTable() {
+  renderNumbeoIndicesTableSection({
+    data: state.countryComparisonData,
+    emptyStateEl: els.countryNumbeoIndicesEmptyState,
+    wrapperEl: els.countryNumbeoIndicesWrapper,
+    headRowEl: els.countryNumbeoIndicesHeadRow,
+    bodyEl: els.countryNumbeoIndicesBody,
+    headLabel: "Index",
+    rows: countryNumbeoIndexRows,
+    sortState: state.countryIndicesSort,
+    keyDataAttr: "data-country-index-key",
+    applySort: applyCountryIndicesSort,
+    getColumnLabel: (country) =>
+      country.country ?? country.country_name ?? country.country_code ?? "Country",
+    getColumnMeta: () => "",
+    getColumnMetaTitle: () => "",
+    getValue: (country, key) => toNumber(country.numbeo_indices?.[key]),
+  });
+}
+
+function renderNumbeoIndicesTableSection({
+  data,
+  emptyStateEl,
+  wrapperEl,
+  headRowEl,
+  bodyEl,
+  headLabel,
+  rows,
+  sortState,
+  keyDataAttr,
+  applySort,
+  getColumnLabel,
+  getColumnMeta,
+  getColumnMetaTitle,
+  getValue,
+}) {
+  if (!data.length) {
+    emptyStateEl.classList.remove("hidden");
+    wrapperEl.classList.add("hidden");
     return;
   }
 
-  els.numbeoIndicesEmptyState.classList.add("hidden");
-  els.numbeoIndicesWrapper.classList.remove("hidden");
+  emptyStateEl.classList.add("hidden");
+  wrapperEl.classList.remove("hidden");
 
-  els.numbeoIndicesHeadRow.innerHTML = `
-    <th>Index</th>
-    ${state.comparisonData
-      .map((city) => {
-        const cityName = city.city ?? city.name ?? "City";
-        const country =
-          city.country ?? city.country_name ?? city.country_code ?? "";
-        const displayCountry = getDisplayCountryName(country);
-        return `<th><span class="table-city-name" title="${escapeHtml(String(cityName))}">${escapeHtml(cityName)}</span><br><span class="table-city-meta" title="${escapeHtml(String(country))}">${escapeHtml(String(displayCountry))}</span></th>`;
+  headRowEl.innerHTML = `
+    <th>${escapeHtml(headLabel)}</th>
+    ${data
+      .map((item) => {
+        const label = getColumnLabel(item);
+        const meta = getColumnMeta(item);
+        const metaTitle = getColumnMetaTitle(item);
+        const metaHtml = meta
+          ? `<br><span class="table-city-meta" title="${escapeHtml(String(metaTitle))}">${escapeHtml(String(meta))}</span>`
+          : "";
+        return `<th><span class="table-city-name" title="${escapeHtml(String(label))}">${escapeHtml(String(label))}</span>${metaHtml}</th>`;
       })
       .join("")}
   `;
 
-  els.numbeoIndicesBody.innerHTML = numbeoIndexRows
+  bodyEl.innerHTML = rows
     .map((row) => {
       const isHigherBetter = row.better === "high";
-      const isActiveSort = state.indicesSort?.key === row.key;
-      const sortDirection = isActiveSort ? state.indicesSort.direction : null;
-      const numericEntries = state.comparisonData
-        .map((city, index) => ({
+      const isActiveSort = sortState?.key === row.key;
+      const sortDirection = isActiveSort ? sortState.direction : null;
+      const numericEntries = data
+        .map((item, index) => ({
           index,
-          numericValue: toNumber(city.numbeo_indices?.[row.key]),
+          numericValue: getValue(item, row.key),
         }))
         .filter((entry) => entry.numericValue != null);
       const numericValues = numericEntries.map((entry) => entry.numericValue);
@@ -810,7 +885,7 @@ function renderNumbeoIndicesTable() {
       const maxValue =
         numericValues.length > 0 ? Math.max(...numericValues) : null;
       const shouldApplySecondary =
-        state.comparisonData.length - numericValues.length < 5 &&
+        data.length - numericValues.length < 5 &&
         numericValues.length >= 3;
       const sortedUniqueValues = shouldApplySecondary
         ? Array.from(new Set(numericValues)).sort((a, b) => a - b)
@@ -822,9 +897,9 @@ function renderNumbeoIndicesTable() {
           ? sortedUniqueValues[sortedUniqueValues.length - 2]
           : null;
 
-      const cells = state.comparisonData
-        .map((city) => {
-          const value = toNumber(city.numbeo_indices?.[row.key]);
+      const cells = data
+        .map((item) => {
+          const value = getValue(item, row.key);
           let cellClass = "indices-value";
 
           if (
@@ -870,7 +945,7 @@ function renderNumbeoIndicesTable() {
             }
           }
 
-          return `<td class="${cellClass}">${escapeHtml(formatIndexValue(value))}</td>`;
+          return `<td class="${cellClass}">${escapeHtml(formatIndexValue(value, row))}</td>`;
         })
         .join("");
 
@@ -880,7 +955,7 @@ function renderNumbeoIndicesTable() {
             <button
               class="cost-item-sort ${isActiveSort ? "is-active" : ""}"
               type="button"
-              data-index-key="${escapeHtml(row.key)}"
+              ${keyDataAttr}="${escapeHtml(row.key)}"
               data-index-sort-direction="${sortDirection ?? ""}"
             >
               <span>${escapeHtml(row.label)}</span>
@@ -893,15 +968,13 @@ function renderNumbeoIndicesTable() {
     })
     .join("");
 
-  els.numbeoIndicesBody
-    .querySelectorAll("[data-index-key]")
-    .forEach((button) => {
-      button.addEventListener("click", () => {
-        const key = button.dataset.indexKey;
-        if (!key) return;
-        applyIndicesSort(key);
-      });
+  bodyEl.querySelectorAll(`[${keyDataAttr}]`).forEach((button) => {
+    button.addEventListener("click", () => {
+      const key = button.getAttribute(keyDataAttr);
+      if (!key) return;
+      applySort(key);
     });
+  });
 }
 
 function buildCostBreakdownDataset(cities) {
@@ -993,10 +1066,12 @@ function resetDashboard() {
   state.selectedCityIds.clear();
   state.cities = [];
   state.comparisonData = [];
+  state.countryComparisonData = [];
   state.costBreakdownData = [];
   state.collapsedCostCategories.clear();
   state.breakdownSort = null;
   state.indicesSort = null;
+  state.countryIndicesSort = null;
   state.climateHiddenCities.clear();
   state.climateHoveredCityKey = null;
 
@@ -1009,6 +1084,7 @@ function resetDashboard() {
   renderSelectedCities();
   renderCostBreakdownTable();
   renderNumbeoIndicesTable();
+  renderCountryNumbeoIndicesTable();
 
   els.chartEmptyState.classList.remove("hidden");
   els.climateChartsGrid.classList.add("hidden");
@@ -1371,8 +1447,16 @@ function formatTooltipValue(value, unit) {
   return `${raw} ${unit}`;
 }
 
-function formatIndexValue(value) {
+function formatIndexValue(value, row = null) {
   if (value == null) return "—";
+  if (row?.format === "currency") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: value >= 100 ? 0 : 2,
+      minimumFractionDigits: value >= 100 ? 0 : 2,
+    }).format(value);
+  }
   return String(value);
 }
 
@@ -1459,6 +1543,21 @@ function applyIndicesSort(key) {
   renderNumbeoIndicesTable();
 }
 
+function applyCountryIndicesSort(key) {
+  if (!state.countryComparisonData.length) return;
+
+  const nextDirection =
+    state.countryIndicesSort?.key === key &&
+    state.countryIndicesSort.direction === "desc"
+      ? "asc"
+      : "desc";
+
+  sortCountryComparisonDataByIndexKey(key, nextDirection);
+  state.countryIndicesSort = { key, direction: nextDirection };
+
+  renderCountryNumbeoIndicesTable();
+}
+
 function applyLoadedComparisonSelection() {
   if (!state.comparisonData.length) return;
 
@@ -1468,18 +1567,23 @@ function applyLoadedComparisonSelection() {
   );
 
   if (state.comparisonData.length === 0) {
+    state.countryComparisonData = [];
     state.costBreakdownData = [];
     state.breakdownSort = null;
     state.indicesSort = null;
+    state.countryIndicesSort = null;
     renderCostBreakdownTable();
     renderNumbeoIndicesTable();
+    renderCountryNumbeoIndicesTable();
     renderClimateChart();
     return;
   }
 
+  syncCountryComparisonDataToSelectedCities();
   state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
   renderCostBreakdownTable();
   renderNumbeoIndicesTable();
+  renderCountryNumbeoIndicesTable();
   renderClimateChart();
 }
 
@@ -1529,12 +1633,100 @@ function sortComparisonDataByIndexKey(key, direction) {
     .map((entry) => entry.city);
 }
 
+function sortCountryComparisonDataByIndexKey(key, direction) {
+  const multiplier = direction === "asc" ? 1 : -1;
+
+  state.countryComparisonData = state.countryComparisonData
+    .map((country, index) => ({
+      country,
+      index,
+      value: toNumber(country.numbeo_indices?.[key]),
+    }))
+    .sort((a, b) => {
+      const aMissing = a.value == null;
+      const bMissing = b.value == null;
+
+      if (aMissing && bMissing) return a.index - b.index;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+      if (a.value === b.value) return a.index - b.index;
+
+      return (a.value - b.value) * multiplier;
+    })
+    .map((entry) => entry.country);
+}
+
 function getCostParamValue(city, param) {
   const prices = city.numbeo_cost?.prices;
   if (!Array.isArray(prices)) return null;
 
   const entry = prices.find((price) => price?.param === param);
   return toNumber(entry?.cost);
+}
+
+async function loadCountryComparisonData(cities) {
+  const countryCodes = Array.from(
+    new Set(
+      cities
+        .map((city) => city.country_code)
+        .filter(Boolean),
+    ),
+  );
+
+  if (countryCodes.length === 0) return [];
+
+  const qs = new URLSearchParams();
+  qs.set("country_codes", countryCodes.join(","));
+  qs.set("include", "numbeo_indices,legatum_indices");
+
+  const res = await fetch(`/countries?${qs.toString()}`);
+  if (!res.ok) {
+    throw new Error(`Failed to load countries: ${res.status}`);
+  }
+
+  const data = await res.json();
+  const countries = Array.isArray(data.countries)
+    ? data.countries
+    : Array.isArray(data.data)
+      ? data.data
+      : [];
+
+  return sortCountriesBySelectedCityCountryOrder(countries, countryCodes);
+}
+
+function syncCountryComparisonDataToSelectedCities() {
+  const selectedCountryCodes = Array.from(
+    new Set(
+      state.comparisonData
+        .map((city) => city.country_code)
+        .filter(Boolean),
+    ),
+  );
+  const selectedCountryCodeSet = new Set(selectedCountryCodes);
+
+  state.countryComparisonData = sortCountriesBySelectedCityCountryOrder(
+    state.countryComparisonData.filter((country) =>
+      selectedCountryCodeSet.has(country.country_code),
+    ),
+    selectedCountryCodes,
+  );
+}
+
+function sortCountriesBySelectedCityCountryOrder(countries, orderedCountryCodes) {
+  const positionByCode = new Map(
+    orderedCountryCodes.map((code, index) => [code, index]),
+  );
+
+  return [...countries].sort((a, b) => {
+    const aPos = positionByCode.get(a.country_code);
+    const bPos = positionByCode.get(b.country_code);
+    if (aPos != null && bPos != null) return aPos - bPos;
+    if (aPos != null) return -1;
+    if (bPos != null) return 1;
+    return String(a.country ?? a.country_code ?? "").localeCompare(
+      String(b.country ?? b.country_code ?? ""),
+    );
+  });
 }
 
 function getDisplayCountryName(country) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -299,6 +299,7 @@ function renderCities() {
     .map((city) => {
       const id = String(city.geoname_id ?? city.city_id ?? city.id ?? "");
       const cityName = city.city ?? city.name ?? id;
+      const cityDisplayName = formatFilterCityName(city);
       const countryName =
         city.country ?? city.country_name ?? city.country_code ?? "";
       const isChecked = state.selectedCityIds.has(id);
@@ -309,7 +310,7 @@ function renderCities() {
         <label class="selection-item">
           <input type="checkbox" data-city-id="${escapeHtml(id)}" ${checked} ${disabled} />
           <div class="selection-item-main">
-            <span class="selection-title">${escapeHtml(cityName)}</span>
+            <span class="selection-title">${cityDisplayName}</span>
             <span class="selection-subtitle">${escapeHtml(countryName)}</span>
           </div>
         </label>
@@ -2029,6 +2030,23 @@ function sortCountriesBySelectedCityCountryOrder(countries, orderedCountryCodes)
 function getDisplayCountryName(country) {
   const raw = String(country ?? "");
   return countryDisplayNames[raw] ?? raw;
+}
+
+function formatFilterCityName(city) {
+  const cityName = city.city ?? city.name ?? "";
+  const countryCode = city.country_code ?? "";
+  const stateCode = city.state_code ?? "";
+
+  if (countryCode !== "USA" || !stateCode.startsWith("US-")) {
+    return escapeHtml(cityName);
+  }
+
+  const shortStateCode = stateCode.slice(3);
+  if (!shortStateCode) {
+    return escapeHtml(cityName);
+  }
+
+  return `${escapeHtml(cityName)} <span class="selection-title-meta">${escapeHtml(shortStateCode)}</span>`;
 }
 
 function escapeHtml(value) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -21,6 +21,9 @@ const els = {
   cityList: document.getElementById("cityList"),
   selectedCountries: document.getElementById("selectedCountries"),
   selectedCities: document.getElementById("selectedCities"),
+  selectedCountriesCount: document.getElementById("selectedCountriesCount"),
+  selectedCitiesCount: document.getElementById("selectedCitiesCount"),
+  selectedCitiesLimitHint: document.getElementById("selectedCitiesLimitHint"),
   compareBtn: document.getElementById("compareBtn"),
   resetBtn: document.getElementById("resetBtn"),
   tableEmptyState: document.getElementById("tableEmptyState"),
@@ -31,10 +34,6 @@ const els = {
   costBreakdownWrapper: document.getElementById("costBreakdownWrapper"),
   costBreakdownHeadRow: document.getElementById("costBreakdownHeadRow"),
   costBreakdownBody: document.getElementById("costBreakdownBody"),
-  metricCities: document.getElementById("metricCities"),
-  metricCountries: document.getElementById("metricCountries"),
-  metricLowestRent: document.getElementById("metricLowestRent"),
-  metricBestQol: document.getElementById("metricBestQol"),
   climateCanvas: document.getElementById("climateChart"),
 };
 
@@ -192,6 +191,7 @@ function renderCountries() {
 
 function renderCities() {
   const q = els.citySearch.value.trim().toLowerCase();
+  const cityLimitReached = state.selectedCityIds.size >= 20;
 
   const filtered = state.cities.filter((city) => {
     const cityName = (city.city ?? city.name ?? "").toLowerCase();
@@ -214,11 +214,13 @@ function renderCities() {
       const cityName = city.city ?? city.name ?? id;
       const countryName =
         city.country ?? city.country_name ?? city.country_code ?? "";
-      const checked = state.selectedCityIds.has(id) ? "checked" : "";
+      const isChecked = state.selectedCityIds.has(id);
+      const checked = isChecked ? "checked" : "";
+      const disabled = cityLimitReached && !isChecked ? "disabled" : "";
 
       return `
         <label class="selection-item">
-          <input type="checkbox" data-city-id="${escapeHtml(id)}" ${checked} />
+          <input type="checkbox" data-city-id="${escapeHtml(id)}" ${checked} ${disabled} />
           <div class="selection-item-main">
             <span class="selection-title">${escapeHtml(cityName)}</span>
             <span class="selection-subtitle">${escapeHtml(countryName)}</span>
@@ -239,6 +241,7 @@ function renderCities() {
         state.selectedCityIds.delete(id);
       }
 
+      renderCities();
       renderSelectedCities();
       updateMetrics();
     });
@@ -657,49 +660,14 @@ function buildCostBreakdownDataset(cities) {
 }
 
 function updateMetrics() {
-  els.metricCities.textContent = String(state.selectedCityIds.size);
-  els.metricCountries.textContent = String(state.selectedCountryCodes.size);
+  const cityCount = state.selectedCityIds.size;
+  const countryCount = state.selectedCountryCodes.size;
+  const cityLimitReached = cityCount >= 20;
 
-  if (!state.comparisonData.length) {
-    els.metricLowestRent.textContent = "—";
-    els.metricBestQol.textContent = "—";
-    return;
-  }
-
-  let lowestRentCity = null;
-  let bestQolCity = null;
-
-  for (const city of state.comparisonData) {
-    const idx = city.numbeo_indices ?? {};
-    const rent = toNumber(idx.rent_index ?? idx.rent);
-    const qol = toNumber(idx.quality_of_life);
-
-    if (rent != null) {
-      if (!lowestRentCity || rent < lowestRentCity.value) {
-        lowestRentCity = {
-          name: city.city ?? city.name ?? "—",
-          value: rent,
-        };
-      }
-    }
-
-    if (qol != null) {
-      if (!bestQolCity || qol > bestQolCity.value) {
-        bestQolCity = {
-          name: city.city ?? city.name ?? "—",
-          value: qol,
-        };
-      }
-    }
-  }
-
-  els.metricLowestRent.textContent = lowestRentCity
-    ? `${lowestRentCity.name} (${fmt(lowestRentCity.value)})`
-    : "—";
-
-  els.metricBestQol.textContent = bestQolCity
-    ? `${bestQolCity.name} (${fmt(bestQolCity.value)})`
-    : "—";
+  els.selectedCitiesCount.textContent = String(cityCount);
+  els.selectedCountriesCount.textContent = String(countryCount);
+  els.selectedCitiesCount.classList.toggle("is-warning", cityLimitReached);
+  els.selectedCitiesLimitHint.classList.toggle("hidden", !cityLimitReached);
 }
 
 function resetDashboard() {

--- a/ui/app.js
+++ b/ui/app.js
@@ -18,25 +18,6 @@ const state = {
   climateHoveredCityKey: null,
 };
 
-const countryDisplayNames = {
-  "Bolivia, Plurinational State of": "Bolivia",
-  "Bosnia and Herzegovina": "Bosnia & Herzegovina",
-  "Dominican Republic": "Dominican Rep.",
-  "Iran, Islamic Republic of": "Iran",
-  "Korea, Republic of": "South Korea",
-  "Moldova, Republic of": "Moldova",
-  "Netherlands, Kingdom of the": "Netherlands",
-  "North Macedonia": "N. Macedonia",
-  "Russian Federation": "Russia",
-  "Syrian Arab Republic": "Syria",
-  "Taiwan, Province of China": "Taiwan",
-  "Tanzania, United Republic of": "Tanzania",
-  "United Arab Emirates": "UAE",
-  "United Kingdom of Great Britain and Northern Ireland": "United Kingdom",
-  "United States of America": "USA",
-  "Venezuela, Bolivarian Republic of": "Venezuela",
-};
-
 const numbeoIndexRows = [
   { key: "quality_of_life", label: "Quality of Life", better: "high" },
   { key: "safety", label: "Safety", better: "high" },
@@ -160,6 +141,138 @@ async function loadInitialData() {
     els.countryList.innerHTML = `<div class="selection-list-empty">Failed to load countries.</div>`;
     els.cityList.innerHTML = `<div class="selection-list-empty">Failed to load cities.</div>`;
   }
+}
+
+function renderTableHeaderRow({
+  headRowEl,
+  headLabel,
+  data,
+  getColumnLabel,
+  getColumnMeta,
+  getHeaderDataAttrs = null,
+}) {
+  headRowEl.innerHTML = `
+    <th>${escapeHtml(headLabel)}</th>
+    ${data
+      .map((item) => {
+        const label = getColumnLabel(item);
+        const meta = getColumnMeta(item);
+        const metaHtml = meta
+          ? `<br><span class="table-city-meta">${escapeHtml(String(meta))}</span>`
+          : "";
+        const headerDataAttrs = getHeaderDataAttrs
+          ? getHeaderDataAttrs(item)
+          : "";
+
+        return `<th><span class="table-header-trigger" ${headerDataAttrs}><span class="table-city-name">${escapeHtml(String(label))}</span>${metaHtml}</span></th>`;
+      })
+      .join("")}
+  `;
+
+  bindHeaderInfoTooltips(headRowEl);
+}
+
+function buildHeatmapScale(values, totalCount) {
+  const numericValues = values
+    .map((value) => toNumber(value))
+    .filter((value) => value != null);
+  const minValue =
+    numericValues.length > 0 ? Math.min(...numericValues) : null;
+  const maxValue =
+    numericValues.length > 0 ? Math.max(...numericValues) : null;
+  const shouldApplySecondary =
+    totalCount - numericValues.length < 5 &&
+    numericValues.length >= 3;
+  const sortedUniqueValues = shouldApplySecondary
+    ? Array.from(new Set(numericValues)).sort((a, b) => a - b)
+    : [];
+
+  return {
+    minValue,
+    maxValue,
+    shouldApplySecondary,
+    secondMinValue:
+      sortedUniqueValues.length >= 3 ? sortedUniqueValues[1] : null,
+    secondMaxValue:
+      sortedUniqueValues.length >= 3
+        ? sortedUniqueValues[sortedUniqueValues.length - 2]
+        : null,
+  };
+}
+
+function getHeatmapClass(value, scale, better = "low") {
+  const numericValue = toNumber(value);
+  if (
+    numericValue == null ||
+    scale.minValue == null ||
+    scale.maxValue == null ||
+    scale.minValue === scale.maxValue
+  ) {
+    return "";
+  }
+
+  const lowerIsBetter = better === "low";
+
+  if (lowerIsBetter) {
+    if (numericValue === scale.minValue) return " cost-value-low";
+    if (numericValue === scale.maxValue) return " cost-value-high";
+    if (
+      scale.shouldApplySecondary &&
+      scale.secondMinValue != null &&
+      numericValue === scale.secondMinValue
+    ) {
+      return " cost-value-low-soft";
+    }
+    if (
+      scale.shouldApplySecondary &&
+      scale.secondMaxValue != null &&
+      numericValue === scale.secondMaxValue
+    ) {
+      return " cost-value-high-soft";
+    }
+    return "";
+  }
+
+  if (numericValue === scale.minValue) return " cost-value-high";
+  if (numericValue === scale.maxValue) return " cost-value-low";
+  if (
+    scale.shouldApplySecondary &&
+    scale.secondMinValue != null &&
+    numericValue === scale.secondMinValue
+  ) {
+    return " cost-value-high-soft";
+  }
+  if (
+    scale.shouldApplySecondary &&
+    scale.secondMaxValue != null &&
+    numericValue === scale.secondMaxValue
+  ) {
+    return " cost-value-low-soft";
+  }
+  return "";
+}
+
+function sortItemsByNumericValue(items, getValue, direction) {
+  const multiplier = direction === "asc" ? 1 : -1;
+
+  return items
+    .map((item, index) => ({
+      item,
+      index,
+      value: toNumber(getValue(item)),
+    }))
+    .sort((a, b) => {
+      const aMissing = a.value == null;
+      const bMissing = b.value == null;
+
+      if (aMissing && bMissing) return a.index - b.index;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+      if (a.value === b.value) return a.index - b.index;
+
+      return (a.value - b.value) * multiplier;
+    })
+    .map((entry) => entry.item);
 }
 
 function buildCountriesFromCities(cities) {
@@ -473,172 +586,6 @@ async function loadComparison() {
   }
 }
 
-function renderClimateChart() {
-  const chartCities = [...state.comparisonData].sort((a, b) => {
-    const aName = (a.city ?? a.name ?? "").toLowerCase();
-    const bName = (b.city ?? b.name ?? "").toLowerCase();
-    return aName.localeCompare(bName);
-  });
-  const labels = [
-    "Jan",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
-  const climateCities = chartCities.map((city, index) =>
-    buildClimateCityConfig(city, index),
-  );
-
-  if (climateCities.length === 0) {
-    els.chartEmptyState.classList.remove("hidden");
-    els.climateChartsGrid.classList.add("hidden");
-    destroyClimateCharts();
-    return;
-  }
-
-  els.chartEmptyState.classList.add("hidden");
-  els.climateChartsGrid.classList.remove("hidden");
-
-  destroyClimateCharts();
-
-  state.climateCharts = [
-    new Chart(
-      els.climateTemperatureCanvas,
-      buildClimateChartConfig({
-        chartKey: "temperature",
-        labels,
-        datasets: climateCities.flatMap((city) => [
-          buildClimateDataset(city, "high_temp", {
-            datasetLabel: `${city.name} high`,
-            cityLabel: city.name,
-            cityKey: city.key,
-            color: city.color,
-            borderDash: [],
-            variant: "high",
-          }),
-          buildClimateDataset(city, "low_temp", {
-            datasetLabel: `${city.name} low`,
-            cityLabel: city.name,
-            cityKey: city.key,
-            color: city.color,
-            borderDash: [8, 5],
-            variant: "low",
-          }),
-        ]),
-        yTitle: "°C",
-        showLegend: true,
-      }),
-    ),
-    new Chart(
-      els.climateSunshineCanvas,
-      buildClimateChartConfig({
-        chartKey: "sunshine",
-        labels,
-        datasets: climateCities.map((city) =>
-          buildClimateDataset(city, "sunshine", {
-            datasetLabel: city.name,
-            cityLabel: city.name,
-            cityKey: city.key,
-            color: city.color,
-          }),
-        ),
-        yTitle: "Hours",
-      }),
-    ),
-    new Chart(
-      els.climateDaylightCanvas,
-      buildClimateChartConfig({
-        chartKey: "daylight",
-        labels,
-        datasets: climateCities.map((city) =>
-          buildClimateDataset(city, "daylight", {
-            datasetLabel: city.name,
-            cityLabel: city.name,
-            cityKey: city.key,
-            color: city.color,
-          }),
-        ),
-        yTitle: "Hours",
-      }),
-    ),
-    new Chart(
-      els.climateHumidityCanvas,
-      buildClimateChartConfig({
-        chartKey: "humidity",
-        labels,
-        datasets: climateCities.map((city) =>
-          buildClimateDataset(city, "humidity", {
-            datasetLabel: city.name,
-            cityLabel: city.name,
-            cityKey: city.key,
-            color: city.color,
-          }),
-        ),
-        yTitle: "%",
-      }),
-    ),
-    new Chart(
-      els.climateRainfallCanvas,
-      buildClimateChartConfig({
-        chartKey: "rainfall",
-        labels,
-        datasets: climateCities.map((city) =>
-          buildClimateDataset(city, "rainfall", {
-            datasetLabel: city.name,
-            cityLabel: city.name,
-            cityKey: city.key,
-            color: city.color,
-          }),
-        ),
-        yTitle: "mm",
-      }),
-    ),
-    new Chart(
-      els.climateWindCanvas,
-      buildClimateChartConfig({
-        chartKey: "wind",
-        labels,
-        datasets: climateCities.map((city) =>
-          buildClimateDataset(city, "wind_speed", {
-            datasetLabel: city.name,
-            cityLabel: city.name,
-            cityKey: city.key,
-            color: city.color,
-          }),
-        ),
-        yTitle: "km/h",
-      }),
-    ),
-    new Chart(
-      els.climateUVIndexCanvas,
-      buildClimateChartConfig({
-        chartKey: "uv_index",
-        labels,
-        datasets: climateCities.map((city) =>
-          buildClimateDataset(city, "uv_index", {
-            datasetLabel: city.name,
-            cityLabel: city.name,
-            cityKey: city.key,
-            color: city.color,
-          }),
-        ),
-        yTitle: "",
-        reserveYAxisTitleSpace: true,
-      }),
-    ),
-  ];
-
-  syncClimateChartStyles();
-}
-
 function renderCostBreakdownTable() {
   if (!state.costBreakdownData.length || !state.comparisonData.length) {
     els.costBreakdownEmptyState.classList.remove("hidden");
@@ -649,20 +596,18 @@ function renderCostBreakdownTable() {
   els.costBreakdownEmptyState.classList.add("hidden");
   els.costBreakdownWrapper.classList.remove("hidden");
 
-  els.costBreakdownHeadRow.innerHTML = `
-    <th>Item</th>
-    ${state.comparisonData
-      .map((city) => {
-        const cityName = city.city ?? city.name ?? "City";
-        const country =
-          city.country ?? city.country_name ?? city.country_code ?? "";
-        const displayCountry = getDisplayCountryName(country);
-        const cityID = String(city.geoname_id ?? city.city_id ?? city.id ?? "");
-        return `<th><span class="table-header-trigger" data-header-kind="city" data-city-id="${escapeHtml(cityID)}"><span class="table-city-name">${escapeHtml(cityName)}</span><br><span class="table-city-meta">${escapeHtml(String(displayCountry))}</span></span></th>`;
-      })
-      .join("")}
-  `;
-  bindHeaderInfoTooltips(els.costBreakdownHeadRow);
+  renderTableHeaderRow({
+    headRowEl: els.costBreakdownHeadRow,
+    headLabel: "Item",
+    data: state.comparisonData,
+    getColumnLabel: (city) => city.city ?? city.name ?? "City",
+    getColumnMeta: (city) =>
+      getDisplayCountryName(
+        city.country ?? city.country_name ?? city.country_code ?? "",
+      ),
+    getHeaderDataAttrs: (city) =>
+      `data-header-kind="city" data-city-id="${escapeHtml(String(city.geoname_id ?? city.city_id ?? city.id ?? ""))}"`,
+  });
 
   els.costBreakdownBody.innerHTML = state.costBreakdownData
     .map((group) => {
@@ -678,78 +623,18 @@ function renderCostBreakdownTable() {
           const sortDirection = isActiveSort
             ? state.breakdownSort.direction
             : null;
-          const numericEntries = item.values
-            .map((value, index) => ({
-              index,
-              numericValue: toNumber(value?.cost),
-            }))
-            .filter((entry) => entry.numericValue != null);
-          const numericValues = numericEntries.map(
-            (entry) => entry.numericValue,
+          const scale = buildHeatmapScale(
+            item.values.map((value) => value?.cost),
+            item.values.length,
           );
-          const minValue =
-            numericValues.length > 0 ? Math.min(...numericValues) : null;
-          const maxValue =
-            numericValues.length > 0 ? Math.max(...numericValues) : null;
-          const shouldApplySecondary =
-            item.values.length - numericValues.length < 5 &&
-            numericValues.length >= 3;
-          const sortedUniqueValues = shouldApplySecondary
-            ? Array.from(new Set(numericValues)).sort((a, b) => a - b)
-            : [];
-          const secondMinValue =
-            sortedUniqueValues.length >= 3 ? sortedUniqueValues[1] : null;
-          const secondMaxValue =
-            sortedUniqueValues.length >= 3
-              ? sortedUniqueValues[sortedUniqueValues.length - 2]
-              : null;
           const cells = item.values
             .map((value) => {
-              const numericValue = toNumber(value?.cost);
               let cellClass = "cost-value";
-
-              if (
-                numericValue != null &&
-                minValue != null &&
-                maxValue != null &&
-                minValue !== maxValue
-              ) {
-                if (isSalaryRow) {
-                  if (numericValue === minValue) {
-                    cellClass += " cost-value-high";
-                  } else if (numericValue === maxValue) {
-                    cellClass += " cost-value-low";
-                  } else if (
-                    shouldApplySecondary &&
-                    secondMinValue != null &&
-                    numericValue === secondMinValue
-                  ) {
-                    cellClass += " cost-value-high-soft";
-                  } else if (
-                    shouldApplySecondary &&
-                    secondMaxValue != null &&
-                    numericValue === secondMaxValue
-                  ) {
-                    cellClass += " cost-value-low-soft";
-                  }
-                } else if (numericValue === minValue) {
-                  cellClass += " cost-value-low";
-                } else if (numericValue === maxValue) {
-                  cellClass += " cost-value-high";
-                } else if (
-                  shouldApplySecondary &&
-                  secondMinValue != null &&
-                  numericValue === secondMinValue
-                ) {
-                  cellClass += " cost-value-low-soft";
-                } else if (
-                  shouldApplySecondary &&
-                  secondMaxValue != null &&
-                  numericValue === secondMaxValue
-                ) {
-                  cellClass += " cost-value-high-soft";
-                }
-              }
+              cellClass += getHeatmapClass(
+                value?.cost,
+                scale,
+                isSalaryRow ? "high" : "low",
+              );
 
               return `<td class="${cellClass}">${escapeHtml(formatCostValue(value, { isMortgageRate: isMortgageRateRow }))}</td>`;
             })
@@ -838,8 +723,6 @@ function renderNumbeoIndicesTable() {
       getDisplayCountryName(
         city.country ?? city.country_name ?? city.country_code ?? "",
       ),
-    getColumnMetaTitle: (city) =>
-      city.country ?? city.country_name ?? city.country_code ?? "",
     getValue: (city, key) => toNumber(city.numbeo_indices?.[key]),
     getHeaderDataAttrs: (city) =>
       `data-header-kind="city" data-city-id="${escapeHtml(String(city.geoname_id ?? city.city_id ?? city.id ?? ""))}"`,
@@ -863,7 +746,6 @@ function renderCountryNumbeoIndicesTable() {
         country.country ?? country.country_name ?? country.country_code ?? "Country",
       ),
     getColumnMeta: () => "",
-    getColumnMetaTitle: () => "",
     getValue: (country, key) => toNumber(country.numbeo_indices?.[key]),
     getHeaderDataAttrs: (country) =>
       `data-header-kind="country" data-country-code="${escapeHtml(String(country.country_code ?? ""))}"`,
@@ -891,7 +773,6 @@ function renderLegatumIndicesTable() {
         country.country ?? country.country_name ?? country.country_code ?? "Country",
       ),
     getColumnMeta: () => "",
-    getColumnMetaTitle: () => "",
     getValue: (country, key) =>
       toNumber(
         country.legatum_indices?.[key]?.[
@@ -920,7 +801,6 @@ function renderNumbeoIndicesTableSection({
   applySort,
   getColumnLabel,
   getColumnMeta,
-  getColumnMetaTitle,
   getValue,
   getHeaderDataAttrs = null,
   getCellDataAttrs = null,
@@ -957,29 +837,10 @@ function renderNumbeoIndicesTableSection({
       const isHigherBetter = row.better === "high";
       const isActiveSort = sortState?.key === row.key;
       const sortDirection = isActiveSort ? sortState.direction : null;
-      const numericEntries = data
-        .map((item, index) => ({
-          index,
-          numericValue: getValue(item, row.key),
-        }))
-        .filter((entry) => entry.numericValue != null);
-      const numericValues = numericEntries.map((entry) => entry.numericValue);
-      const minValue =
-        numericValues.length > 0 ? Math.min(...numericValues) : null;
-      const maxValue =
-        numericValues.length > 0 ? Math.max(...numericValues) : null;
-      const shouldApplySecondary =
-        data.length - numericValues.length < 5 &&
-        numericValues.length >= 3;
-      const sortedUniqueValues = shouldApplySecondary
-        ? Array.from(new Set(numericValues)).sort((a, b) => a - b)
-        : [];
-      const secondMinValue =
-        sortedUniqueValues.length >= 3 ? sortedUniqueValues[1] : null;
-      const secondMaxValue =
-        sortedUniqueValues.length >= 3
-          ? sortedUniqueValues[sortedUniqueValues.length - 2]
-          : null;
+      const scale = buildHeatmapScale(
+        data.map((item) => getValue(item, row.key)),
+        data.length,
+      );
 
       const cells = data
         .map((item) => {
@@ -988,49 +849,11 @@ function renderNumbeoIndicesTableSection({
             ? getCellDataAttrs(item, row)
             : "";
           let cellClass = "indices-value";
-
-          if (
-            value != null &&
-            minValue != null &&
-            maxValue != null &&
-            minValue !== maxValue
-          ) {
-            if (isHigherBetter) {
-              if (value === minValue) {
-                cellClass += " cost-value-high";
-              } else if (value === maxValue) {
-                cellClass += " cost-value-low";
-              } else if (
-                shouldApplySecondary &&
-                secondMinValue != null &&
-                value === secondMinValue
-              ) {
-                cellClass += " cost-value-high-soft";
-              } else if (
-                shouldApplySecondary &&
-                secondMaxValue != null &&
-                value === secondMaxValue
-              ) {
-                cellClass += " cost-value-low-soft";
-              }
-            } else if (value === minValue) {
-              cellClass += " cost-value-low";
-            } else if (value === maxValue) {
-              cellClass += " cost-value-high";
-            } else if (
-              shouldApplySecondary &&
-              secondMinValue != null &&
-              value === secondMinValue
-            ) {
-              cellClass += " cost-value-low-soft";
-            } else if (
-              shouldApplySecondary &&
-              secondMaxValue != null &&
-              value === secondMaxValue
-            ) {
-              cellClass += " cost-value-high-soft";
-            }
-          }
+          cellClass += getHeatmapClass(
+            value,
+            scale,
+            isHigherBetter ? "high" : "low",
+          );
 
           return `<td class="${cellClass}" ${cellDataAttrs}>${escapeHtml(formatIndexValue(value, row))}</td>`;
         })
@@ -1062,147 +885,6 @@ function renderNumbeoIndicesTableSection({
       applySort(key);
     });
   });
-}
-
-function bindHeaderInfoTooltips(container) {
-  container
-    .querySelectorAll(".table-header-trigger[data-header-kind]")
-    .forEach((cell) => {
-      cell.addEventListener("mouseenter", () => {
-        showHeaderInfoTooltip(cell);
-      });
-      cell.addEventListener("mousemove", (event) => {
-        positionHeaderInfoTooltip(event.clientX, event.clientY);
-      });
-      cell.addEventListener("mouseleave", hideHeaderInfoTooltip);
-    });
-}
-
-function showHeaderInfoTooltip(cell) {
-  const kind = cell.dataset.headerKind;
-  if (!kind) return;
-
-  const tooltipEl = getHeaderInfoTooltipElement();
-  const content = kind === "city"
-    ? buildCityHeaderTooltipContent(cell.dataset.cityId)
-    : buildCountryHeaderTooltipContent(cell.dataset.countryCode);
-
-  if (!content) {
-    tooltipEl.classList.remove("is-visible");
-    return;
-  }
-
-  tooltipEl.innerHTML = content;
-  tooltipEl.classList.add("is-visible");
-}
-
-function hideHeaderInfoTooltip() {
-  getHeaderInfoTooltipElement().classList.remove("is-visible");
-}
-
-function positionHeaderInfoTooltip(clientX, clientY) {
-  const tooltipEl = getHeaderInfoTooltipElement();
-  if (!tooltipEl.classList.contains("is-visible")) return;
-
-  const offset = 14;
-  const rect = tooltipEl.getBoundingClientRect();
-  let left = clientX + offset;
-  let top = clientY + offset;
-
-  if (left + rect.width > window.innerWidth - 12) {
-    left = clientX - rect.width - offset;
-  }
-  if (top + rect.height > window.innerHeight - 12) {
-    top = clientY - rect.height - offset;
-  }
-
-  tooltipEl.style.left = `${Math.max(12, left)}px`;
-  tooltipEl.style.top = `${Math.max(12, top)}px`;
-}
-
-function getHeaderInfoTooltipElement() {
-  let tooltipEl = document.querySelector(".header-info-tooltip");
-  if (!tooltipEl) {
-    tooltipEl = document.createElement("div");
-    tooltipEl.className = "header-info-tooltip";
-    document.body.appendChild(tooltipEl);
-  }
-  return tooltipEl;
-}
-
-function buildCityHeaderTooltipContent(cityID) {
-  if (!cityID) return "";
-
-  const city = state.comparisonData.find(
-    (item) => String(item.geoname_id ?? item.city_id ?? item.id ?? "") === String(cityID),
-  );
-  if (!city) return "";
-
-  const cityName = city.city ?? city.name ?? "City";
-  const population = formatCompactPopulation(city.population);
-  const utcOffset = formatUTCOffset(city.timezone);
-
-  return `
-    <div class="header-info-title">${escapeHtml(cityName)}</div>
-    <div class="header-info-row"><span class="header-info-key">Pop.</span><span class="header-info-value">${escapeHtml(population)}</span></div>
-    <div class="header-info-row"><span class="header-info-key">UTC</span><span class="header-info-value">${escapeHtml(utcOffset)}</span></div>
-  `;
-}
-
-function buildCountryHeaderTooltipContent(countryCode) {
-  if (!countryCode) return "";
-
-  const country = state.countryComparisonData.find(
-    (item) => String(item.country_code ?? "") === String(countryCode),
-  );
-  if (!country) return "";
-
-  const countryName =
-    country.country ?? country.country_name ?? country.country_code ?? "Country";
-  const population = formatCompactPopulation(country.population);
-  const area = formatCompactArea(country.area);
-
-  return `
-    <div class="header-info-title">${escapeHtml(countryName)}</div>
-    <div class="header-info-row"><span class="header-info-key">Pop.</span><span class="header-info-value">${escapeHtml(population)}</span></div>
-    <div class="header-info-row"><span class="header-info-key">Area</span><span class="header-info-value">${escapeHtml(area)}</span></div>
-  `;
-}
-
-function formatCompactPopulation(value) {
-  const n = toNumber(value);
-  if (n == null) return "—";
-  return new Intl.NumberFormat("en-US", {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  }).format(n);
-}
-
-function formatCompactArea(value) {
-  const n = toNumber(value);
-  if (n == null) return "—";
-  return `${new Intl.NumberFormat("en-US", {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  }).format(n)} km²`;
-}
-
-function formatUTCOffset(timezone) {
-  if (!timezone) return "—";
-
-  try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: timezone,
-      timeZoneName: "shortOffset",
-    }).formatToParts(new Date());
-    const timeZoneName =
-      parts.find((part) => part.type === "timeZoneName")?.value ?? "";
-
-    if (!timeZoneName) return String(timezone);
-    return timeZoneName.replace("GMT", "UTC");
-  } catch {
-    return String(timezone);
-  }
 }
 
 function buildCostBreakdownDataset(cities) {
@@ -1339,602 +1021,6 @@ function expandFilters() {
   els.editFiltersBtn.classList.add("hidden");
 }
 
-function normalizeMonthlySeries(arr) {
-  const out = new Array(12).fill(null);
-  for (let i = 0; i < Math.min(arr.length, 12); i += 1) {
-    out[i] = toNumber(arr[i]);
-  }
-  return out;
-}
-
-function buildClimateCityConfig(city, index) {
-  const climate = city.avg_climate ?? buildPlaceholderClimate(city, index);
-  const key = String(city.geoname_id ?? city.city_id ?? city.id ?? city.city ?? index);
-  return {
-    key,
-    name: city.city ?? city.name ?? `City ${index + 1}`,
-    climate,
-    color: getClimateColor(index),
-  };
-}
-
-function buildPlaceholderClimate(city, index) {
-  const offset = index * 1.4;
-  return {
-    high_temp: [5, 7, 11, 16, 21, 25, 28, 28, 23, 17, 11, 7].map((v) => v + offset),
-    low_temp: [-1, 0, 3, 8, 13, 17, 20, 20, 16, 10, 5, 1].map((v) => v + offset),
-    sunshine: [3, 4, 5, 7, 8, 9, 10, 9, 7, 5, 4, 3].map((v) => Math.max(0, v - index * 0.2)),
-    daylight: [9, 10, 12, 13, 15, 16, 15, 14, 12, 11, 9, 8].map((v) => v),
-    humidity: [76, 74, 71, 69, 68, 66, 64, 65, 68, 72, 75, 77].map((v) => v + index),
-    rainfall: [62, 58, 61, 67, 72, 76, 81, 79, 70, 66, 64, 68].map((v) => v + index * 4),
-    wind_speed: [14, 13, 13, 12, 11, 10, 9, 9, 10, 11, 12, 13].map((v) => Math.max(3, v - index * 0.3)),
-    uv_index: [1, 2, 3, 5, 6, 7, 8, 7, 5, 3, 2, 1].map((v) => Math.min(11, Math.max(0, v + index * 0.2))),
-  };
-}
-
-function getClimateColor(index) {
-  const palette = [
-    "#2563eb",
-    "#ef4444",
-    "#0f766e",
-    "#d97706",
-    "#7c3aed",
-    "#db2777",
-    "#0891b2",
-    "#65a30d",
-    "#c2410c",
-    "#475569",
-    "#16a34a",
-    "#ea580c",
-    "#4f46e5",
-    "#be123c",
-    "#0d9488",
-  ];
-  return palette[index % palette.length];
-}
-
-function buildClimateDataset(city, metricKey, options = {}) {
-  const rawSeries = city.climate?.[metricKey] ?? [];
-  const baseColor = options.color ?? city.color;
-  return {
-    label: options.datasetLabel ?? city.name,
-    data: normalizeMonthlySeries(rawSeries),
-    borderColor: baseColor,
-    backgroundColor: withAlpha(baseColor, 0.12),
-    borderWidth: 2.5,
-    tension: 0.35,
-    pointRadius: 0,
-    pointHoverRadius: 4,
-    pointHitRadius: 14,
-    fill: false,
-    borderDash: options.borderDash ?? [],
-    cityKey: options.cityKey ?? city.key,
-    cityLabel: options.cityLabel ?? city.name,
-    variant: options.variant ?? "default",
-    _baseColor: baseColor,
-  };
-}
-
-function buildClimateChartConfig({
-  chartKey,
-  labels,
-  datasets,
-  yTitle,
-  reserveYAxisTitleSpace = false,
-  showLegend = false,
-}) {
-  return {
-    type: "line",
-    data: { labels, datasets },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      interaction: {
-        mode: "nearest",
-        intersect: false,
-      },
-      onHover: (_event, elements, chart) => {
-        const hoveredDataset = elements.length > 0
-          ? chart.data.datasets[elements[0].datasetIndex]
-          : null;
-        setHoveredClimateCity(hoveredDataset?.cityKey ?? null);
-      },
-      plugins: {
-        legend: showLegend
-          ? {
-              position: "top",
-              labels: {
-                usePointStyle: true,
-                pointStyle: "circle",
-                boxWidth: 10,
-                boxHeight: 10,
-                padding: 14,
-                font: {
-                  size: 13,
-                  lineHeight: 1.15,
-                },
-                generateLabels: (chart) => {
-                  const seen = new Set();
-                  const labels = [];
-                  chart.data.datasets.forEach((dataset, datasetIndex) => {
-                    if (seen.has(dataset.cityKey)) return;
-                    seen.add(dataset.cityKey);
-                    const isHidden = state.climateHiddenCities.has(dataset.cityKey);
-                    labels.push({
-                      text: dataset.cityLabel,
-                      fillStyle: withAlpha(dataset._baseColor, isHidden ? 0.18 : 0.9),
-                      strokeStyle: withAlpha(dataset._baseColor, isHidden ? 0.18 : 0.9),
-                      lineWidth: 2,
-                      hidden: isHidden,
-                      datasetIndex,
-                      cityKey: dataset.cityKey,
-                    });
-                  });
-                  return labels;
-                },
-              },
-              onClick: (_event, legendItem) => {
-                const cityKey = legendItem.cityKey;
-                if (!cityKey) return;
-                if (state.climateHiddenCities.has(cityKey)) {
-                  state.climateHiddenCities.delete(cityKey);
-                } else {
-                  state.climateHiddenCities.add(cityKey);
-                }
-                syncClimateChartStyles();
-              },
-            }
-          : {
-              display: false,
-            },
-        tooltip: {
-          enabled: false,
-          mode: "nearest",
-          intersect: false,
-          external: (context) =>
-            renderClimateTooltip(context, { chartKey, yTitle }),
-        },
-      },
-      scales: {
-        x: {
-          grid: {
-            color: "rgba(148, 163, 184, 0.12)",
-          },
-          ticks: {
-            color: "#64748b",
-          },
-        },
-        y: {
-          grid: {
-            color: "rgba(148, 163, 184, 0.12)",
-          },
-          ticks: {
-            color: "#64748b",
-          },
-          title: {
-            display: Boolean(yTitle) || reserveYAxisTitleSpace,
-            text: yTitle || " ",
-            color: yTitle ? "#64748b" : "rgba(0,0,0,0)",
-            font: {
-              size: 12,
-              weight: "600",
-            },
-          },
-        },
-      },
-      elements: {
-        line: {
-          capBezierPoints: true,
-        },
-      },
-    },
-    plugins: [
-      {
-        id: `climate-hover-reset-${chartKey}`,
-        afterEvent: (_chart, args) => {
-          if (args.event.type === "mouseout") {
-            setHoveredClimateCity(null);
-          }
-        },
-      },
-    ],
-  };
-}
-
-function destroyClimateCharts() {
-  state.climateCharts.forEach((chart) => chart.destroy());
-  state.climateCharts = [];
-}
-
-function setHoveredClimateCity(cityKey) {
-  if (state.climateHoveredCityKey === cityKey) return;
-  state.climateHoveredCityKey = cityKey;
-  syncClimateChartStyles();
-}
-
-function syncClimateChartStyles() {
-  state.climateCharts.forEach((chart) => {
-    chart.data.datasets.forEach((dataset) => {
-      const isHidden = state.climateHiddenCities.has(dataset.cityKey);
-      const isHovered =
-        state.climateHoveredCityKey &&
-        state.climateHoveredCityKey === dataset.cityKey;
-      const shouldFade =
-        state.climateHoveredCityKey && !isHovered;
-      const baseColor = getBaseDatasetColor(dataset);
-      const isLowVariant = dataset.variant === "low";
-      const alpha = isHidden
-        ? 0.06
-        : shouldFade
-          ? isLowVariant ? 0.18 : 0.3
-          : isHovered
-            ? isLowVariant ? 0.86 : 1
-            : isLowVariant ? 0.5 : 0.76;
-
-      dataset.hidden = isHidden;
-      dataset.borderColor = withAlpha(baseColor, alpha);
-      dataset.backgroundColor = withAlpha(
-        baseColor,
-        isHidden ? 0.03 : shouldFade ? 0.05 : isLowVariant ? 0.08 : 0.15,
-      );
-      dataset.borderWidth = isHovered
-        ? isLowVariant ? 2.3 : 3.3
-        : isLowVariant ? 1.7 : 2.2;
-      dataset.pointRadius = isHovered ? 2.5 : 0;
-    });
-    chart.update("none");
-  });
-}
-
-function renderClimateTooltip(context, options) {
-  const { chart, tooltip } = context;
-  const tooltipEl = getClimateTooltipElement(chart);
-
-  if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
-    tooltipEl.classList.remove("is-visible");
-    return;
-  }
-
-  const dataPoint = tooltip.dataPoints[0];
-  const dataset = dataPoint.dataset;
-  const cityKey = dataset.cityKey;
-  const cityLabel = dataset.cityLabel;
-  const monthLabel = dataPoint.label;
-  const color = dataset._baseColor ?? "#2563eb";
-
-  let contentHtml = "";
-  if (options.chartKey === "temperature") {
-    const highDataset = chart.data.datasets.find(
-      (item) => item.cityKey === cityKey && item.variant === "high",
-    );
-    const lowDataset = chart.data.datasets.find(
-      (item) => item.cityKey === cityKey && item.variant === "low",
-    );
-    const highValue = toNumber(highDataset?.data?.[dataPoint.dataIndex]);
-    const lowValue = toNumber(lowDataset?.data?.[dataPoint.dataIndex]);
-    const highParts = formatTooltipValueParts(highValue, "°C");
-    const lowParts = formatTooltipValueParts(lowValue, "°C");
-    const highHtml = `
-      <span class="chart-tooltip-value-number">${escapeHtml(highParts.value)}</span>${highParts.unit ? ` <span class="chart-tooltip-unit">${escapeHtml(highParts.unit)}</span>` : ""}
-    `;
-    const lowHtml = `
-      <span class="chart-tooltip-value-number">${escapeHtml(lowParts.value)}</span>${lowParts.unit ? ` <span class="chart-tooltip-unit">${escapeHtml(lowParts.unit)}</span>` : ""}
-    `;
-    contentHtml = `
-      <div class="chart-tooltip-city">${escapeHtml(cityLabel)}</div>
-      <div class="chart-tooltip-text">${escapeHtml(monthLabel)}:</div>
-      <div class="chart-tooltip-metric">
-        <span class="chart-tooltip-key">High:</span>
-        <span class="chart-tooltip-value">${highHtml}</span>
-      </div>
-      <div class="chart-tooltip-metric">
-        <span class="chart-tooltip-key">Low:</span>
-        <span class="chart-tooltip-value">${lowHtml}</span>
-      </div>
-    `;
-  } else {
-    const value = toNumber(dataPoint.parsed?.y);
-    const valueParts = formatTooltipValueParts(value, options.yTitle);
-    const valueHtml = valueParts.unit
-      ? `${escapeHtml(valueParts.value)} <span class="chart-tooltip-unit">${escapeHtml(valueParts.unit)}</span>`
-      : escapeHtml(valueParts.value);
-    contentHtml = `
-      <div class="chart-tooltip-city">${escapeHtml(cityLabel)}</div>
-      <div class="chart-tooltip-metric chart-tooltip-metric-inline">
-        <span class="chart-tooltip-key">${escapeHtml(monthLabel)}</span>
-        <span class="chart-tooltip-value">${valueHtml}</span>
-      </div>
-    `;
-  }
-
-  tooltipEl.innerHTML = `
-    <div class="chart-tooltip-row">
-      <span class="chart-tooltip-swatch" style="background:${escapeHtml(color)}"></span>
-      <div>${contentHtml}</div>
-    </div>
-  `;
-
-  const { offsetLeft: positionX, offsetTop: positionY } = chart.canvas;
-  tooltipEl.style.left = `${positionX + tooltip.caretX + 14}px`;
-  tooltipEl.style.top = `${positionY + tooltip.caretY - 12}px`;
-  tooltipEl.classList.add("is-visible");
-}
-
-function getClimateTooltipElement(chart) {
-  const parent = chart.canvas.parentNode;
-  let tooltipEl = parent.querySelector(".chart-tooltip");
-
-  if (!tooltipEl) {
-    tooltipEl = document.createElement("div");
-    tooltipEl.className = "chart-tooltip";
-    parent.appendChild(tooltipEl);
-  }
-
-  return tooltipEl;
-}
-
-function formatTooltipValue(value, unit) {
-  if (value == null) return "—";
-  const raw = String(value);
-  if (unit === "%" || unit === "mm") {
-    return `${raw}${unit}`;
-  }
-  if (unit === "km/h") {
-    return `${raw} km/h`;
-  }
-  if (unit === "UV") {
-    return raw;
-  }
-  if (unit === "Hours") {
-    return `${raw} h`;
-  }
-  if (unit === "°C") {
-    return `${raw}${unit}`;
-  }
-  return `${raw} ${unit}`;
-}
-
-function formatTooltipValueParts(value, unit) {
-  if (value == null) {
-    return { value: "—", unit: "" };
-  }
-
-  const raw = String(value);
-  if (unit === "%" || unit === "mm" || unit === "°C") {
-    return { value: raw, unit };
-  }
-  if (unit === "" || unit === "UV") {
-    return { value: raw, unit: "" };
-  }
-  if (unit === "km/h") {
-    return { value: raw, unit: "km/h" };
-  }
-  if (unit === "Hours") {
-    return { value: raw, unit: "h" };
-  }
-  return { value: raw, unit };
-}
-
-function formatIndexValue(value, row = null) {
-  if (value == null) return "—";
-  if (row?.format === "currency") {
-    return new Intl.NumberFormat("en-US", {
-      style: "currency",
-      currency: "USD",
-      maximumFractionDigits: value >= 100 ? 0 : 2,
-      minimumFractionDigits: value >= 100 ? 0 : 2,
-    }).format(value);
-  }
-  return String(value);
-}
-
-function bindLegatumTooltipEvents() {
-  els.legatumIndicesBody
-    .querySelectorAll("[data-legatum-row-key][data-legatum-country-code]")
-    .forEach((cell) => {
-      cell.addEventListener("mouseenter", () => {
-        showLegatumTooltip(cell);
-      });
-      cell.addEventListener("mousemove", (event) => {
-        positionLegatumTooltip(event.clientX, event.clientY);
-      });
-      cell.addEventListener("mouseleave", hideLegatumTooltip);
-    });
-}
-
-function showLegatumTooltip(cell) {
-  const rowKey = cell.dataset.legatumRowKey;
-  const countryCode = cell.dataset.legatumCountryCode;
-  if (!rowKey || !countryCode) return;
-
-  const country = state.countryComparisonData.find(
-    (item) => item.country_code === countryCode,
-  );
-  const row = legatumIndexRows.find((item) => item.key === rowKey);
-  if (!country || !row) return;
-
-  const tooltipEl = getLegatumTooltipElement();
-  const isRankMode = state.legatumMetricMode === "rank";
-  const series = buildLegatumSeries(
-    country.legatum_indices?.[rowKey],
-    isRankMode ? "rank" : "score",
-  );
-  if (!series.length) {
-    tooltipEl.classList.remove("is-visible");
-    return;
-  }
-
-  const values = series.map((point) => point.value);
-  const minValue = Math.min(...values);
-  const maxValue = Math.max(...values);
-  const currentPoint = series[series.length - 1];
-  const displayCountry = getDisplayCountryName(
-    country.country ?? country.country_name ?? country.country_code ?? countryCode,
-  );
-
-  tooltipEl.innerHTML = `
-    <div class="legatum-tooltip-title">${escapeHtml(displayCountry)}</div>
-    <div class="legatum-tooltip-subtitle">${escapeHtml(row.label)} • ${escapeHtml(isRankMode ? "Rank" : "Score")}</div>
-    <div class="legatum-tooltip-current">${escapeHtml(String(currentPoint.year))}: ${escapeHtml(String(currentPoint.value))}</div>
-    <div class="legatum-tooltip-chart">
-      ${renderLegatumSparkline(series, { minValue, maxValue, isRankMode })}
-    </div>
-  `;
-  tooltipEl.classList.add("is-visible");
-}
-
-function hideLegatumTooltip() {
-  getLegatumTooltipElement().classList.remove("is-visible");
-}
-
-function positionLegatumTooltip(clientX, clientY) {
-  const tooltipEl = getLegatumTooltipElement();
-  if (!tooltipEl.classList.contains("is-visible")) return;
-
-  const offset = 16;
-  const { innerWidth, innerHeight } = window;
-  const rect = tooltipEl.getBoundingClientRect();
-  let left = clientX + offset;
-  let top = clientY + offset;
-
-  if (left + rect.width > innerWidth - 12) {
-    left = clientX - rect.width - offset;
-  }
-  if (top + rect.height > innerHeight - 12) {
-    top = clientY - rect.height - offset;
-  }
-
-  tooltipEl.style.left = `${Math.max(12, left)}px`;
-  tooltipEl.style.top = `${Math.max(12, top)}px`;
-}
-
-function getLegatumTooltipElement() {
-  let tooltipEl = document.querySelector(".legatum-tooltip");
-  if (!tooltipEl) {
-    tooltipEl = document.createElement("div");
-    tooltipEl.className = "legatum-tooltip";
-    document.body.appendChild(tooltipEl);
-  }
-  return tooltipEl;
-}
-
-function buildLegatumSeries(entry, mode) {
-  if (!entry) return [];
-
-  return legatumYears
-    .map((year) => ({
-      year,
-      value: toNumber(entry[`${mode}_${year}`]),
-    }))
-    .filter((point) => point.value != null);
-}
-
-function renderLegatumSparkline(series, { minValue, maxValue, isRankMode }) {
-  const width = 230;
-  const height = 122;
-  const padding = { top: 10, right: 30, bottom: 24, left: 8 };
-  const plotWidth = width - padding.left - padding.right;
-  const plotHeight = height - padding.top - padding.bottom;
-  const range = maxValue - minValue || 1;
-  const midYear = 2015;
-  const midX =
-    padding.left +
-    (plotWidth * (midYear - legatumYears[0])) /
-      Math.max(1, legatumYears.length - 1);
-  const midValue = (minValue + maxValue) / 2;
-  const midNormalized = isRankMode
-    ? (maxValue - midValue) / range
-    : (midValue - minValue) / range;
-  const midY = padding.top + plotHeight - midNormalized * plotHeight;
-
-  const points = series.map((point, index) => {
-    const x =
-      padding.left +
-      (plotWidth * index) / Math.max(1, series.length - 1);
-    const normalized = isRankMode
-      ? (maxValue - point.value) / range
-      : (point.value - minValue) / range;
-    const y = padding.top + plotHeight - normalized * plotHeight;
-    return { ...point, x, y };
-  });
-
-  const polylinePoints = points.map((point) => `${point.x},${point.y}`).join(" ");
-  const stroke = isRankMode ? "#2563eb" : "#0f766e";
-  const topAxisValue = isRankMode ? minValue : maxValue;
-  const bottomAxisValue = isRankMode ? maxValue : minValue;
-
-  return `
-    <svg viewBox="0 0 ${width} ${height}" class="legatum-tooltip-sparkline" aria-hidden="true">
-      <line x1="${padding.left}" y1="${padding.top}" x2="${width - padding.right}" y2="${padding.top}" class="legatum-tooltip-grid" />
-      <line x1="${padding.left}" y1="${midY}" x2="${width - padding.right}" y2="${midY}" class="legatum-tooltip-grid legatum-tooltip-grid-mid" />
-      <line x1="${padding.left}" y1="${padding.top + plotHeight}" x2="${width - padding.right}" y2="${padding.top + plotHeight}" class="legatum-tooltip-grid" />
-      <line x1="${midX}" y1="${padding.top + plotHeight}" x2="${midX}" y2="${padding.top + plotHeight + 5}" class="legatum-tooltip-axis-tick legatum-tooltip-axis-tick-mid" />
-      <polyline points="${polylinePoints}" fill="none" stroke="${stroke}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
-      <circle cx="${points[0].x}" cy="${points[0].y}" r="2.5" fill="${stroke}" />
-      <circle cx="${points[points.length - 1].x}" cy="${points[points.length - 1].y}" r="3" fill="${stroke}" />
-      <text x="${width - 2}" y="${padding.top + 4}" text-anchor="end" class="legatum-tooltip-y-label">${escapeHtml(String(topAxisValue))}</text>
-      <text x="${width - 2}" y="${midY + 3}" text-anchor="end" class="legatum-tooltip-y-label legatum-tooltip-y-label-mid">${escapeHtml(formatLegatumAxisMidValue(midValue))}</text>
-      <text x="${width - 2}" y="${padding.top + plotHeight}" text-anchor="end" dominant-baseline="ideographic" class="legatum-tooltip-y-label">${escapeHtml(String(bottomAxisValue))}</text>
-      <text x="${padding.left}" y="${height - 4}" text-anchor="start" class="legatum-tooltip-x-label">2007</text>
-      <text x="${midX}" y="${height - 4}" text-anchor="middle" class="legatum-tooltip-x-label legatum-tooltip-x-label-mid">2015</text>
-      <text x="${width - padding.right}" y="${height - 4}" text-anchor="end" class="legatum-tooltip-x-label">2023</text>
-    </svg>
-  `;
-}
-
-function formatLegatumAxisMidValue(value) {
-  if (!Number.isFinite(value)) return "—";
-  return String(Math.round(value));
-}
-
-function getBaseDatasetColor(dataset) {
-  return dataset._baseColor ?? "#2563eb";
-}
-
-function withAlpha(color, alpha) {
-  const hex = color.replace("#", "");
-  const normalized =
-    hex.length === 3
-      ? hex
-          .split("")
-          .map((char) => char + char)
-          .join("")
-      : hex;
-  const r = parseInt(normalized.slice(0, 2), 16);
-  const g = parseInt(normalized.slice(2, 4), 16);
-  const b = parseInt(normalized.slice(4, 6), 16);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-function toNumber(value) {
-  if (value == null) return null;
-  const n = Number(value);
-  return Number.isFinite(n) ? n : null;
-}
-
-function fmt(value) {
-  const n = toNumber(value);
-  return n == null ? "—" : n.toFixed(1);
-}
-
-function formatCostValue(value, options = {}) {
-  if (!value) return "—";
-  const n = toNumber(value.cost);
-  if (n == null) return "—";
-
-  if (options.isMortgageRate) {
-    return `${n.toFixed(2)}%`;
-  }
-
-  const fractionDigits = n >= 100 ? 0 : 2;
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: value.currency ?? "USD",
-    maximumFractionDigits: fractionDigits,
-    minimumFractionDigits: fractionDigits,
-  }).format(n);
-}
-
 function applyBreakdownSort(param) {
   if (!state.comparisonData.length) return;
 
@@ -2046,97 +1132,38 @@ function applyLoadedComparisonSelection() {
 }
 
 function sortComparisonDataByCostParam(param, direction) {
-  const multiplier = direction === "asc" ? 1 : -1;
-
-  state.comparisonData = state.comparisonData
-    .map((city, index) => ({
-      city,
-      index,
-      value: getCostParamValue(city, param),
-    }))
-    .sort((a, b) => {
-      const aMissing = a.value == null;
-      const bMissing = b.value == null;
-
-      if (aMissing && bMissing) return a.index - b.index;
-      if (aMissing) return 1;
-      if (bMissing) return -1;
-      if (a.value === b.value) return a.index - b.index;
-
-      return (a.value - b.value) * multiplier;
-    })
-    .map((entry) => entry.city);
+  state.comparisonData = sortItemsByNumericValue(
+    state.comparisonData,
+    (city) => getCostParamValue(city, param),
+    direction,
+  );
 }
 
 function sortComparisonDataByIndexKey(key, direction) {
-  const multiplier = direction === "asc" ? 1 : -1;
-
-  state.comparisonData = state.comparisonData
-    .map((city, index) => ({
-      city,
-      index,
-      value: toNumber(city.numbeo_indices?.[key]),
-    }))
-    .sort((a, b) => {
-      const aMissing = a.value == null;
-      const bMissing = b.value == null;
-
-      if (aMissing && bMissing) return a.index - b.index;
-      if (aMissing) return 1;
-      if (bMissing) return -1;
-      if (a.value === b.value) return a.index - b.index;
-
-      return (a.value - b.value) * multiplier;
-    })
-    .map((entry) => entry.city);
+  state.comparisonData = sortItemsByNumericValue(
+    state.comparisonData,
+    (city) => city.numbeo_indices?.[key],
+    direction,
+  );
 }
 
 function sortCountryComparisonDataByIndexKey(key, direction) {
-  const multiplier = direction === "asc" ? 1 : -1;
-
-  state.countryComparisonData = state.countryComparisonData
-    .map((country, index) => ({
-      country,
-      index,
-      value: toNumber(country.numbeo_indices?.[key]),
-    }))
-    .sort((a, b) => {
-      const aMissing = a.value == null;
-      const bMissing = b.value == null;
-
-      if (aMissing && bMissing) return a.index - b.index;
-      if (aMissing) return 1;
-      if (bMissing) return -1;
-      if (a.value === b.value) return a.index - b.index;
-
-      return (a.value - b.value) * multiplier;
-    })
-    .map((entry) => entry.country);
+  state.countryComparisonData = sortItemsByNumericValue(
+    state.countryComparisonData,
+    (country) => country.numbeo_indices?.[key],
+    direction,
+  );
 }
 
 function sortCountryComparisonDataByLegatumKey(key, direction) {
-  const multiplier = direction === "asc" ? 1 : -1;
   const metricKey =
     state.legatumMetricMode === "rank" ? "rank_2023" : "score_2023";
 
-  state.countryComparisonData = state.countryComparisonData
-    .map((country, index) => ({
-      country,
-      index,
-      value: toNumber(country.legatum_indices?.[key]?.[metricKey]),
-    }))
-    .sort((a, b) => {
-      const aMissing = a.value == null;
-      const bMissing = b.value == null;
-
-      if (aMissing && bMissing) return a.index - b.index;
-      if (aMissing) return 1;
-      if (bMissing) return -1;
-      if (a.value === b.value) return a.index - b.index;
-
-      return (a.value - b.value) * multiplier;
-    })
-    .map((entry) => entry.country);
+  state.countryComparisonData = sortItemsByNumericValue(
+    state.countryComparisonData,
+    (country) => country.legatum_indices?.[key]?.[metricKey],
+    direction,
+  );
 }
 
 function syncLegatumToggleButtons() {
@@ -2218,11 +1245,6 @@ function sortCountriesBySelectedCityCountryOrder(countries, orderedCountryCodes)
   });
 }
 
-function getDisplayCountryName(country) {
-  const raw = String(country ?? "");
-  return countryDisplayNames[raw] ?? raw;
-}
-
 function formatFilterCityName(city) {
   const cityName = city.city ?? city.name ?? "";
   const countryCode = city.country_code ?? "";
@@ -2238,13 +1260,4 @@ function formatFilterCityName(city) {
   }
 
   return `${escapeHtml(cityName)} <span class="selection-title-meta">${escapeHtml(shortStateCode)}</span>`;
-}
-
-function escapeHtml(value) {
-  return String(value)
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#039;");
 }

--- a/ui/app.js
+++ b/ui/app.js
@@ -11,6 +11,25 @@ const state = {
   climateChart: null,
 };
 
+const countryDisplayNames = {
+  "Bolivia, Plurinational State of": "Bolivia",
+  "Bosnia and Herzegovina": "Bosnia & Herzegovina",
+  "Dominican Republic": "Dominican Rep.",
+  "Iran, Islamic Republic of": "Iran",
+  "Korea, Republic of": "South Korea",
+  "Moldova, Republic of": "Moldova",
+  "Netherlands, Kingdom of the": "Netherlands",
+  "North Macedonia": "N. Macedonia",
+  "Russian Federation": "Russia",
+  "Syrian Arab Republic": "Syria",
+  "Taiwan, Province of China": "Taiwan",
+  "Tanzania, United Republic of": "Tanzania",
+  "United Arab Emirates": "UAE",
+  "United Kingdom of Great Britain and Northern Ireland": "United Kingdom",
+  "United States of America": "USA",
+  "Venezuela, Bolivarian Republic of": "Venezuela",
+};
+
 const els = {
   filtersCard: document.querySelector(".filters-card"),
   filtersBody: document.getElementById("filtersBody"),
@@ -260,14 +279,15 @@ function renderSelectedCountries() {
       const code = country.country_code ?? country.code ?? "";
       const name =
         country.country ?? country.country_name ?? country.name ?? "";
+      const displayName = getDisplayCountryName(name);
       return `
         <span class="chip chip-dismissible">
-          <span>${escapeHtml(name)}</span>
+          <span>${escapeHtml(displayName)}</span>
           <button
             type="button"
             class="chip-remove"
             data-remove-country="${escapeHtml(code)}"
-            aria-label="Remove ${escapeHtml(name)}"
+            aria-label="Remove ${escapeHtml(displayName)}"
           >
             ×
           </button>
@@ -469,8 +489,10 @@ function renderCostBreakdownTable() {
     ${state.comparisonData
       .map((city) => {
         const cityName = city.city ?? city.name ?? "City";
-        const country = city.country_code ?? city.country ?? "";
-        return `<th><span class="table-city-name">${escapeHtml(cityName)}</span><br><span class="table-city-meta">${escapeHtml(String(country))}</span></th>`;
+        const country =
+          city.country ?? city.country_name ?? city.country_code ?? "";
+        const displayCountry = getDisplayCountryName(country);
+        return `<th><span class="table-city-name" title="${escapeHtml(String(cityName))}">${escapeHtml(cityName)}</span><br><span class="table-city-meta" title="${escapeHtml(String(country))}">${escapeHtml(String(displayCountry))}</span></th>`;
       })
       .join("")}
   `;
@@ -483,22 +505,28 @@ function renderCostBreakdownTable() {
           const isSalaryRow =
             item.param === "Average Monthly Net Salary (After Tax)";
           const isMortgageRateRow =
-            item.param === "Annual Mortgage Interest Rate (20-Year Fixed, in %)";
+            item.param ===
+            "Annual Mortgage Interest Rate (20-Year Fixed, in %)";
           const isActiveSort = state.breakdownSort?.param === item.param;
-          const sortDirection = isActiveSort ? state.breakdownSort.direction : null;
+          const sortDirection = isActiveSort
+            ? state.breakdownSort.direction
+            : null;
           const numericEntries = item.values
             .map((value, index) => ({
               index,
               numericValue: toNumber(value?.cost),
             }))
             .filter((entry) => entry.numericValue != null);
-          const numericValues = numericEntries.map((entry) => entry.numericValue);
+          const numericValues = numericEntries.map(
+            (entry) => entry.numericValue,
+          );
           const minValue =
             numericValues.length > 0 ? Math.min(...numericValues) : null;
           const maxValue =
             numericValues.length > 0 ? Math.max(...numericValues) : null;
           const shouldApplySecondary =
-            item.values.length - numericValues.length <= 1 && numericValues.length >= 3;
+            item.values.length - numericValues.length <= 1 &&
+            numericValues.length >= 3;
           const sortedUniqueValues = shouldApplySecondary
             ? Array.from(new Set(numericValues)).sort((a, b) => a - b)
             : [];
@@ -513,24 +541,45 @@ function renderCostBreakdownTable() {
               const numericValue = toNumber(value?.cost);
               let cellClass = "cost-value";
 
-              if (numericValue != null && minValue != null && maxValue != null && minValue !== maxValue) {
+              if (
+                numericValue != null &&
+                minValue != null &&
+                maxValue != null &&
+                minValue !== maxValue
+              ) {
                 if (isSalaryRow) {
                   if (numericValue === minValue) {
                     cellClass += " cost-value-high";
                   } else if (numericValue === maxValue) {
                     cellClass += " cost-value-low";
-                  } else if (shouldApplySecondary && secondMinValue != null && numericValue === secondMinValue) {
+                  } else if (
+                    shouldApplySecondary &&
+                    secondMinValue != null &&
+                    numericValue === secondMinValue
+                  ) {
                     cellClass += " cost-value-high-soft";
-                  } else if (shouldApplySecondary && secondMaxValue != null && numericValue === secondMaxValue) {
+                  } else if (
+                    shouldApplySecondary &&
+                    secondMaxValue != null &&
+                    numericValue === secondMaxValue
+                  ) {
                     cellClass += " cost-value-low-soft";
                   }
                 } else if (numericValue === minValue) {
                   cellClass += " cost-value-low";
                 } else if (numericValue === maxValue) {
                   cellClass += " cost-value-high";
-                } else if (shouldApplySecondary && secondMinValue != null && numericValue === secondMinValue) {
+                } else if (
+                  shouldApplySecondary &&
+                  secondMinValue != null &&
+                  numericValue === secondMinValue
+                ) {
                   cellClass += " cost-value-low-soft";
-                } else if (shouldApplySecondary && secondMaxValue != null && numericValue === secondMaxValue) {
+                } else if (
+                  shouldApplySecondary &&
+                  secondMaxValue != null &&
+                  numericValue === secondMaxValue
+                ) {
                   cellClass += " cost-value-high-soft";
                 }
               }
@@ -772,7 +821,8 @@ function applyBreakdownSort(param) {
   if (!state.comparisonData.length) return;
 
   const nextDirection =
-    state.breakdownSort?.param === param && state.breakdownSort.direction === "desc"
+    state.breakdownSort?.param === param &&
+    state.breakdownSort.direction === "desc"
       ? "asc"
       : "desc";
 
@@ -833,6 +883,11 @@ function getCostParamValue(city, param) {
 
   const entry = prices.find((price) => price?.param === param);
   return toNumber(entry?.cost);
+}
+
+function getDisplayCountryName(country) {
+  const raw = String(country ?? "");
+  return countryDisplayNames[raw] ?? raw;
 }
 
 function escapeHtml(value) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -630,7 +630,8 @@ function renderClimateChart() {
             color: city.color,
           }),
         ),
-        yTitle: "UV",
+        yTitle: "",
+        reserveYAxisTitleSpace: true,
       }),
     ),
   ];
@@ -656,10 +657,12 @@ function renderCostBreakdownTable() {
         const country =
           city.country ?? city.country_name ?? city.country_code ?? "";
         const displayCountry = getDisplayCountryName(country);
-        return `<th><span class="table-city-name" title="${escapeHtml(String(cityName))}">${escapeHtml(cityName)}</span><br><span class="table-city-meta" title="${escapeHtml(String(country))}">${escapeHtml(String(displayCountry))}</span></th>`;
+        const cityID = String(city.geoname_id ?? city.city_id ?? city.id ?? "");
+        return `<th><span class="table-header-trigger" data-header-kind="city" data-city-id="${escapeHtml(cityID)}"><span class="table-city-name">${escapeHtml(cityName)}</span><br><span class="table-city-meta">${escapeHtml(String(displayCountry))}</span></span></th>`;
       })
       .join("")}
   `;
+  bindHeaderInfoTooltips(els.costBreakdownHeadRow);
 
   els.costBreakdownBody.innerHTML = state.costBreakdownData
     .map((group) => {
@@ -838,6 +841,8 @@ function renderNumbeoIndicesTable() {
     getColumnMetaTitle: (city) =>
       city.country ?? city.country_name ?? city.country_code ?? "",
     getValue: (city, key) => toNumber(city.numbeo_indices?.[key]),
+    getHeaderDataAttrs: (city) =>
+      `data-header-kind="city" data-city-id="${escapeHtml(String(city.geoname_id ?? city.city_id ?? city.id ?? ""))}"`,
   });
 }
 
@@ -860,6 +865,8 @@ function renderCountryNumbeoIndicesTable() {
     getColumnMeta: () => "",
     getColumnMetaTitle: () => "",
     getValue: (country, key) => toNumber(country.numbeo_indices?.[key]),
+    getHeaderDataAttrs: (country) =>
+      `data-header-kind="country" data-country-code="${escapeHtml(String(country.country_code ?? ""))}"`,
   });
 }
 
@@ -891,6 +898,8 @@ function renderLegatumIndicesTable() {
           isRankMode ? "rank_2023" : "score_2023"
         ],
       ),
+    getHeaderDataAttrs: (country) =>
+      `data-header-kind="country" data-country-code="${escapeHtml(String(country.country_code ?? ""))}"`,
     getCellDataAttrs: (country, row) =>
       `data-legatum-row-key="${escapeHtml(row.key)}" data-legatum-country-code="${escapeHtml(String(country.country_code ?? ""))}"`,
   });
@@ -913,6 +922,7 @@ function renderNumbeoIndicesTableSection({
   getColumnMeta,
   getColumnMetaTitle,
   getValue,
+  getHeaderDataAttrs = null,
   getCellDataAttrs = null,
 }) {
   if (!data.length) {
@@ -930,14 +940,17 @@ function renderNumbeoIndicesTableSection({
       .map((item) => {
         const label = getColumnLabel(item);
         const meta = getColumnMeta(item);
-        const metaTitle = getColumnMetaTitle(item);
         const metaHtml = meta
-          ? `<br><span class="table-city-meta" title="${escapeHtml(String(metaTitle))}">${escapeHtml(String(meta))}</span>`
+          ? `<br><span class="table-city-meta">${escapeHtml(String(meta))}</span>`
           : "";
-        return `<th><span class="table-city-name" title="${escapeHtml(String(label))}">${escapeHtml(String(label))}</span>${metaHtml}</th>`;
+        const headerDataAttrs = getHeaderDataAttrs
+          ? getHeaderDataAttrs(item)
+          : "";
+        return `<th><span class="table-header-trigger" ${headerDataAttrs}><span class="table-city-name">${escapeHtml(String(label))}</span>${metaHtml}</span></th>`;
       })
       .join("")}
   `;
+  bindHeaderInfoTooltips(headRowEl);
 
   bodyEl.innerHTML = rows
     .map((row) => {
@@ -1049,6 +1062,147 @@ function renderNumbeoIndicesTableSection({
       applySort(key);
     });
   });
+}
+
+function bindHeaderInfoTooltips(container) {
+  container
+    .querySelectorAll(".table-header-trigger[data-header-kind]")
+    .forEach((cell) => {
+      cell.addEventListener("mouseenter", () => {
+        showHeaderInfoTooltip(cell);
+      });
+      cell.addEventListener("mousemove", (event) => {
+        positionHeaderInfoTooltip(event.clientX, event.clientY);
+      });
+      cell.addEventListener("mouseleave", hideHeaderInfoTooltip);
+    });
+}
+
+function showHeaderInfoTooltip(cell) {
+  const kind = cell.dataset.headerKind;
+  if (!kind) return;
+
+  const tooltipEl = getHeaderInfoTooltipElement();
+  const content = kind === "city"
+    ? buildCityHeaderTooltipContent(cell.dataset.cityId)
+    : buildCountryHeaderTooltipContent(cell.dataset.countryCode);
+
+  if (!content) {
+    tooltipEl.classList.remove("is-visible");
+    return;
+  }
+
+  tooltipEl.innerHTML = content;
+  tooltipEl.classList.add("is-visible");
+}
+
+function hideHeaderInfoTooltip() {
+  getHeaderInfoTooltipElement().classList.remove("is-visible");
+}
+
+function positionHeaderInfoTooltip(clientX, clientY) {
+  const tooltipEl = getHeaderInfoTooltipElement();
+  if (!tooltipEl.classList.contains("is-visible")) return;
+
+  const offset = 14;
+  const rect = tooltipEl.getBoundingClientRect();
+  let left = clientX + offset;
+  let top = clientY + offset;
+
+  if (left + rect.width > window.innerWidth - 12) {
+    left = clientX - rect.width - offset;
+  }
+  if (top + rect.height > window.innerHeight - 12) {
+    top = clientY - rect.height - offset;
+  }
+
+  tooltipEl.style.left = `${Math.max(12, left)}px`;
+  tooltipEl.style.top = `${Math.max(12, top)}px`;
+}
+
+function getHeaderInfoTooltipElement() {
+  let tooltipEl = document.querySelector(".header-info-tooltip");
+  if (!tooltipEl) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "header-info-tooltip";
+    document.body.appendChild(tooltipEl);
+  }
+  return tooltipEl;
+}
+
+function buildCityHeaderTooltipContent(cityID) {
+  if (!cityID) return "";
+
+  const city = state.comparisonData.find(
+    (item) => String(item.geoname_id ?? item.city_id ?? item.id ?? "") === String(cityID),
+  );
+  if (!city) return "";
+
+  const cityName = city.city ?? city.name ?? "City";
+  const population = formatCompactPopulation(city.population);
+  const utcOffset = formatUTCOffset(city.timezone);
+
+  return `
+    <div class="header-info-title">${escapeHtml(cityName)}</div>
+    <div class="header-info-row"><span class="header-info-key">Pop.</span><span class="header-info-value">${escapeHtml(population)}</span></div>
+    <div class="header-info-row"><span class="header-info-key">UTC</span><span class="header-info-value">${escapeHtml(utcOffset)}</span></div>
+  `;
+}
+
+function buildCountryHeaderTooltipContent(countryCode) {
+  if (!countryCode) return "";
+
+  const country = state.countryComparisonData.find(
+    (item) => String(item.country_code ?? "") === String(countryCode),
+  );
+  if (!country) return "";
+
+  const countryName =
+    country.country ?? country.country_name ?? country.country_code ?? "Country";
+  const population = formatCompactPopulation(country.population);
+  const area = formatCompactArea(country.area);
+
+  return `
+    <div class="header-info-title">${escapeHtml(countryName)}</div>
+    <div class="header-info-row"><span class="header-info-key">Pop.</span><span class="header-info-value">${escapeHtml(population)}</span></div>
+    <div class="header-info-row"><span class="header-info-key">Area</span><span class="header-info-value">${escapeHtml(area)}</span></div>
+  `;
+}
+
+function formatCompactPopulation(value) {
+  const n = toNumber(value);
+  if (n == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n);
+}
+
+function formatCompactArea(value) {
+  const n = toNumber(value);
+  if (n == null) return "—";
+  return `${new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n)} km²`;
+}
+
+function formatUTCOffset(timezone) {
+  if (!timezone) return "—";
+
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "shortOffset",
+    }).formatToParts(new Date());
+    const timeZoneName =
+      parts.find((part) => part.type === "timeZoneName")?.value ?? "";
+
+    if (!timeZoneName) return String(timezone);
+    return timeZoneName.replace("GMT", "UTC");
+  } catch {
+    return String(timezone);
+  }
 }
 
 function buildCostBreakdownDataset(cities) {
@@ -1266,6 +1420,7 @@ function buildClimateChartConfig({
   labels,
   datasets,
   yTitle,
+  reserveYAxisTitleSpace = false,
   showLegend = false,
 }) {
   return {
@@ -1357,9 +1512,9 @@ function buildClimateChartConfig({
             color: "#64748b",
           },
           title: {
-            display: true,
-            text: yTitle,
-            color: "#64748b",
+            display: Boolean(yTitle) || reserveYAxisTitleSpace,
+            text: yTitle || " ",
+            color: yTitle ? "#64748b" : "rgba(0,0,0,0)",
             font: {
               size: 12,
               weight: "600",
@@ -1457,23 +1612,38 @@ function renderClimateTooltip(context, options) {
     );
     const highValue = toNumber(highDataset?.data?.[dataPoint.dataIndex]);
     const lowValue = toNumber(lowDataset?.data?.[dataPoint.dataIndex]);
+    const highParts = formatTooltipValueParts(highValue, "°C");
+    const lowParts = formatTooltipValueParts(lowValue, "°C");
+    const highHtml = `
+      <span class="chart-tooltip-value-number">${escapeHtml(highParts.value)}</span>${highParts.unit ? ` <span class="chart-tooltip-unit">${escapeHtml(highParts.unit)}</span>` : ""}
+    `;
+    const lowHtml = `
+      <span class="chart-tooltip-value-number">${escapeHtml(lowParts.value)}</span>${lowParts.unit ? ` <span class="chart-tooltip-unit">${escapeHtml(lowParts.unit)}</span>` : ""}
+    `;
     contentHtml = `
       <div class="chart-tooltip-city">${escapeHtml(cityLabel)}</div>
       <div class="chart-tooltip-text">${escapeHtml(monthLabel)}:</div>
       <div class="chart-tooltip-metric">
         <span class="chart-tooltip-key">High:</span>
-        <span class="chart-tooltip-value">${escapeHtml(formatTooltipValue(highValue, "°C"))}</span>
+        <span class="chart-tooltip-value">${highHtml}</span>
       </div>
       <div class="chart-tooltip-metric">
         <span class="chart-tooltip-key">Low:</span>
-        <span class="chart-tooltip-value">${escapeHtml(formatTooltipValue(lowValue, "°C"))}</span>
+        <span class="chart-tooltip-value">${lowHtml}</span>
       </div>
     `;
   } else {
     const value = toNumber(dataPoint.parsed?.y);
+    const valueParts = formatTooltipValueParts(value, options.yTitle);
+    const valueHtml = valueParts.unit
+      ? `${escapeHtml(valueParts.value)} <span class="chart-tooltip-unit">${escapeHtml(valueParts.unit)}</span>`
+      : escapeHtml(valueParts.value);
     contentHtml = `
       <div class="chart-tooltip-city">${escapeHtml(cityLabel)}</div>
-      <div class="chart-tooltip-text">${escapeHtml(monthLabel)}: ${escapeHtml(formatTooltipValue(value, options.yTitle))}</div>
+      <div class="chart-tooltip-metric chart-tooltip-metric-inline">
+        <span class="chart-tooltip-key">${escapeHtml(monthLabel)}</span>
+        <span class="chart-tooltip-value">${valueHtml}</span>
+      </div>
     `;
   }
 
@@ -1522,6 +1692,27 @@ function formatTooltipValue(value, unit) {
     return `${raw}${unit}`;
   }
   return `${raw} ${unit}`;
+}
+
+function formatTooltipValueParts(value, unit) {
+  if (value == null) {
+    return { value: "—", unit: "" };
+  }
+
+  const raw = String(value);
+  if (unit === "%" || unit === "mm" || unit === "°C") {
+    return { value: raw, unit };
+  }
+  if (unit === "" || unit === "UV") {
+    return { value: raw, unit: "" };
+  }
+  if (unit === "km/h") {
+    return { value: raw, unit: "km/h" };
+  }
+  if (unit === "Hours") {
+    return { value: raw, unit: "h" };
+  }
+  return { value: raw, unit };
 }
 
 function formatIndexValue(value, row = null) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -448,7 +448,7 @@ function renderCostBreakdownTable() {
       .map((city) => {
         const cityName = city.city ?? city.name ?? "City";
         const country = city.country_code ?? city.country ?? "";
-        return `<th>${escapeHtml(cityName)}<br><span class="selection-subtitle">${escapeHtml(String(country))}</span></th>`;
+        return `<th><span class="table-city-name">${escapeHtml(cityName)}</span><br><span class="table-city-meta">${escapeHtml(String(country))}</span></th>`;
       })
       .join("")}
   `;

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,4 +1,5 @@
 const state = {
+  allCities: [],
   countries: [],
   cities: [],
   selectedCountryCodes: new Set(),
@@ -8,6 +9,9 @@ const state = {
 };
 
 const els = {
+  filtersCard: document.querySelector(".filters-card"),
+  filtersBody: document.getElementById("filtersBody"),
+  editFiltersBtn: document.getElementById("editFiltersBtn"),
   countrySearch: document.getElementById("countrySearch"),
   citySearch: document.getElementById("citySearch"),
   countryList: document.getElementById("countryList"),
@@ -29,7 +33,7 @@ const els = {
 
 document.addEventListener("DOMContentLoaded", () => {
   bindEvents();
-  loadCountries();
+  loadInitialData();
 });
 
 function bindEvents() {
@@ -37,81 +41,89 @@ function bindEvents() {
   els.citySearch.addEventListener("input", renderCities);
   els.compareBtn.addEventListener("click", loadComparison);
   els.resetBtn.addEventListener("click", resetDashboard);
+  els.editFiltersBtn.addEventListener("click", expandFilters);
 }
 
-async function loadCountries() {
+async function loadInitialData() {
   try {
-    const res = await fetch("/countries");
-    if (!res.ok) throw new Error(`Failed to load countries: ${res.status}`);
+    const res = await fetch("/cities");
+    if (!res.ok) throw new Error(`Failed to load cities: ${res.status}`);
 
     const data = await res.json();
-
-    // Expected flexible parsing
-    state.countries = Array.isArray(data.countries)
-      ? data.countries
+    state.allCities = Array.isArray(data.cities)
+      ? data.cities
       : Array.isArray(data.data)
         ? data.data
         : [];
+    state.countries = buildCountriesFromCities(state.allCities);
 
     renderCountries();
+    renderCities();
     renderSelectedCountries();
+    renderSelectedCities();
     updateMetrics();
   } catch (error) {
     console.error(error);
     els.countryList.innerHTML = `<div class="empty-state">Failed to load countries.</div>`;
+    els.cityList.innerHTML = `<div class="empty-state">Failed to load cities.</div>`;
   }
 }
 
-async function loadCitiesForSelectedCountries() {
+function buildCountriesFromCities(cities) {
+  const countryMap = new Map();
+
+  for (const city of cities) {
+    const code = city.country_code ?? city.code;
+    const name = city.country ?? city.country_name ?? code;
+    if (!code || !name || countryMap.has(code)) continue;
+
+    countryMap.set(code, {
+      country_code: code,
+      country: name,
+    });
+  }
+
+  return Array.from(countryMap.values()).sort((a, b) =>
+    a.country.localeCompare(b.country),
+  );
+}
+
+function filterCitiesForSelectedCountries() {
   const selectedCodes = Array.from(state.selectedCountryCodes);
-  state.cities = [];
-  state.selectedCityIds.clear();
 
   if (selectedCodes.length === 0) {
+    state.cities = [];
+    state.selectedCityIds.clear();
     renderCities();
     renderSelectedCities();
     updateMetrics();
     return;
   }
 
-  try {
-    const results = await Promise.all(
-      selectedCodes.map((code) =>
-        fetch(`/cities?country_code=${encodeURIComponent(code)}`).then(
-          (res) => {
-            if (res.status === 404) return { cities: [] };
-            if (!res.ok) throw new Error(`Failed to load cities for ${code}`);
-            return res.json();
-          },
-        ),
-      ),
-    );
-
-    const allCities = results.flatMap((data) => {
-      if (Array.isArray(data.cities)) return data.cities;
-      if (Array.isArray(data.data)) return data.data;
-      return [];
-    });
-
-    const uniqueMap = new Map();
-    for (const city of allCities) {
-      const id = city.geoname_id ?? city.city_id ?? city.id;
-      if (id != null) uniqueMap.set(String(id), city);
-    }
-
-    state.cities = Array.from(uniqueMap.values()).sort((a, b) => {
+  const selectedCodeSet = new Set(selectedCodes);
+  state.cities = state.allCities
+    .filter((city) => selectedCodeSet.has(city.country_code))
+    .sort((a, b) => {
       const aName = (a.city ?? a.name ?? "").toLowerCase();
       const bName = (b.city ?? b.name ?? "").toLowerCase();
       return aName.localeCompare(bName);
     });
 
-    renderCities();
-    renderSelectedCities();
-    updateMetrics();
-  } catch (error) {
-    console.error(error);
-    els.cityList.innerHTML = `<div class="empty-state">Failed to load cities.</div>`;
+  const availableCityIDs = new Set(
+    state.cities.map((city) =>
+      String(city.geoname_id ?? city.city_id ?? city.id ?? ""),
+    ),
+  );
+
+  for (const cityID of Array.from(state.selectedCityIds)) {
+    if (!availableCityIDs.has(cityID)) {
+      state.selectedCityIds.delete(cityID);
+    }
   }
+
+  renderCities();
+  renderSelectedCities();
+  updateMetrics();
 }
 
 function renderCountries() {
@@ -155,7 +167,7 @@ function renderCountries() {
   els.countryList
     .querySelectorAll("input[data-country-code]")
     .forEach((input) => {
-      input.addEventListener("change", async (e) => {
+      input.addEventListener("change", (e) => {
         const code = e.target.dataset.countryCode;
         if (!code) return;
 
@@ -166,8 +178,7 @@ function renderCountries() {
         }
 
         renderSelectedCountries();
-        updateMetrics();
-        await loadCitiesForSelectedCountries();
+        filterCitiesForSelectedCountries();
       });
     });
 }
@@ -182,7 +193,11 @@ function renderCities() {
   });
 
   if (filtered.length === 0) {
-    els.cityList.innerHTML = `<div class="empty-state">Select countries to load cities.</div>`;
+    if (state.selectedCountryCodes.size === 0) {
+      els.cityList.innerHTML = `<div class="empty-state">Select countries to load cities.</div>`;
+    } else {
+      els.cityList.innerHTML = `<div class="empty-state">No cities match the current selection.</div>`;
+    }
     return;
   }
 
@@ -286,6 +301,7 @@ async function loadComparison() {
     renderComparisonTable();
     renderClimateChart();
     updateMetrics();
+    collapseFilters();
   } catch (error) {
     console.error(error);
     alert("Failed to load comparison data.");
@@ -469,6 +485,17 @@ function resetDashboard() {
   }
 
   updateMetrics();
+  expandFilters();
+}
+
+function collapseFilters() {
+  els.filtersCard.classList.add("is-collapsed");
+  els.editFiltersBtn.classList.remove("hidden");
+}
+
+function expandFilters() {
+  els.filtersCard.classList.remove("is-collapsed");
+  els.editFiltersBtn.classList.add("hidden");
 }
 
 function normalizeMonthlySeries(arr) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -12,6 +12,7 @@ const state = {
   indicesSort: null,
   countryIndicesSort: null,
   legatumIndicesSort: null,
+  legatumMetricMode: "score",
   climateCharts: [],
   climateHiddenCities: new Set(),
   climateHoveredCityKey: null,
@@ -104,6 +105,8 @@ const els = {
   legatumIndicesWrapper: document.getElementById("legatumIndicesWrapper"),
   legatumIndicesHeadRow: document.getElementById("legatumIndicesHeadRow"),
   legatumIndicesBody: document.getElementById("legatumIndicesBody"),
+  legatumScoreToggle: document.getElementById("legatumScoreToggle"),
+  legatumRankToggle: document.getElementById("legatumRankToggle"),
   climateTemperatureCanvas: document.getElementById("climateTemperatureChart"),
   climateSunshineCanvas: document.getElementById("climateSunshineChart"),
   climateDaylightCanvas: document.getElementById("climateDaylightChart"),
@@ -124,6 +127,12 @@ function bindEvents() {
   els.compareBtn.addEventListener("click", loadComparison);
   els.resetBtn.addEventListener("click", resetDashboard);
   els.editFiltersBtn.addEventListener("click", expandFilters);
+  els.legatumScoreToggle.addEventListener("click", () =>
+    setLegatumMetricMode("score"),
+  );
+  els.legatumRankToggle.addEventListener("click", () =>
+    setLegatumMetricMode("rank"),
+  );
 }
 
 async function loadInitialData() {
@@ -852,6 +861,7 @@ function renderCountryNumbeoIndicesTable() {
 }
 
 function renderLegatumIndicesTable() {
+  const isRankMode = state.legatumMetricMode === "rank";
   renderNumbeoIndicesTableSection({
     data: state.countryComparisonData,
     emptyStateEl: els.legatumIndicesEmptyState,
@@ -859,7 +869,10 @@ function renderLegatumIndicesTable() {
     headRowEl: els.legatumIndicesHeadRow,
     bodyEl: els.legatumIndicesBody,
     headLabel: "Index",
-    rows: legatumIndexRows,
+    rows: legatumIndexRows.map((row) => ({
+      ...row,
+      better: isRankMode ? "low" : "high",
+    })),
     sortState: state.legatumIndicesSort,
     keyDataAttr: "data-legatum-index-key",
     applySort: applyLegatumIndicesSort,
@@ -869,8 +882,14 @@ function renderLegatumIndicesTable() {
       ),
     getColumnMeta: () => "",
     getColumnMetaTitle: () => "",
-    getValue: (country, key) => toNumber(country.legatum_indices?.[key]?.score_2023),
+    getValue: (country, key) =>
+      toNumber(
+        country.legatum_indices?.[key]?.[
+          isRankMode ? "rank_2023" : "score_2023"
+        ],
+      ),
   });
+  syncLegatumToggleButtons();
 }
 
 function renderNumbeoIndicesTableSection({
@@ -1118,6 +1137,7 @@ function resetDashboard() {
   state.indicesSort = null;
   state.countryIndicesSort = null;
   state.legatumIndicesSort = null;
+  state.legatumMetricMode = "score";
   state.climateHiddenCities.clear();
   state.climateHoveredCityKey = null;
 
@@ -1624,6 +1644,15 @@ function applyLegatumIndicesSort(key) {
   renderLegatumIndicesTable();
 }
 
+function setLegatumMetricMode(mode) {
+  if (mode !== "score" && mode !== "rank") return;
+  if (state.legatumMetricMode === mode) return;
+
+  state.legatumMetricMode = mode;
+  state.legatumIndicesSort = null;
+  renderLegatumIndicesTable();
+}
+
 function applyLoadedComparisonSelection() {
   if (!state.comparisonData.length) return;
 
@@ -1727,12 +1756,14 @@ function sortCountryComparisonDataByIndexKey(key, direction) {
 
 function sortCountryComparisonDataByLegatumKey(key, direction) {
   const multiplier = direction === "asc" ? 1 : -1;
+  const metricKey =
+    state.legatumMetricMode === "rank" ? "rank_2023" : "score_2023";
 
   state.countryComparisonData = state.countryComparisonData
     .map((country, index) => ({
       country,
       index,
-      value: toNumber(country.legatum_indices?.[key]?.score_2023),
+      value: toNumber(country.legatum_indices?.[key]?.[metricKey]),
     }))
     .sort((a, b) => {
       const aMissing = a.value == null;
@@ -1746,6 +1777,12 @@ function sortCountryComparisonDataByLegatumKey(key, direction) {
       return (a.value - b.value) * multiplier;
     })
     .map((entry) => entry.country);
+}
+
+function syncLegatumToggleButtons() {
+  const isScoreMode = state.legatumMetricMode === "score";
+  els.legatumScoreToggle.classList.toggle("is-active", isScoreMode);
+  els.legatumRankToggle.classList.toggle("is-active", !isScoreMode);
 }
 
 function getCostParamValue(city, param) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -7,6 +7,7 @@ const state = {
   comparisonData: [],
   costBreakdownData: [],
   collapsedCostCategories: new Set(),
+  breakdownSort: null,
   climateChart: null,
 };
 
@@ -303,6 +304,7 @@ async function loadComparison() {
       : Array.isArray(data.data)
         ? data.data
         : [];
+    state.breakdownSort = null;
     state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
 
     renderComparisonTable();
@@ -350,6 +352,11 @@ function renderComparisonTable() {
 }
 
 function renderClimateChart() {
+  const chartCities = [...state.comparisonData].sort((a, b) => {
+    const aName = (a.city ?? a.name ?? "").toLowerCase();
+    const bName = (b.city ?? b.name ?? "").toLowerCase();
+    return aName.localeCompare(bName);
+  });
   const datasets = [];
   const labels = [
     "Jan",
@@ -366,7 +373,7 @@ function renderClimateChart() {
     "Dec",
   ];
 
-  for (const city of state.comparisonData) {
+  for (const city of chartCities) {
     const climate = city.avg_climate ?? {};
     const highTemp =
       climate.high_temp ?? climate.high_temps ?? climate.avg_high_temp ?? [];
@@ -455,6 +462,8 @@ function renderCostBreakdownTable() {
             item.param === "Average Monthly Net Salary (After Tax)";
           const isMortgageRateRow =
             item.param === "Annual Mortgage Interest Rate (20-Year Fixed, in %)";
+          const isActiveSort = state.breakdownSort?.param === item.param;
+          const sortDirection = isActiveSort ? state.breakdownSort.direction : null;
           const numericEntries = item.values
             .map((value, index) => ({
               index,
@@ -510,7 +519,17 @@ function renderCostBreakdownTable() {
 
           return `
             <tr ${isCollapsed ? 'class="hidden"' : ""}>
-              <td class="cost-item-name">${escapeHtml(item.param)}</td>
+              <td class="cost-item-name">
+                <button
+                  class="cost-item-sort ${isActiveSort ? "is-active" : ""}"
+                  type="button"
+                  data-cost-param="${escapeHtml(item.param)}"
+                  data-cost-sort-direction="${sortDirection ?? ""}"
+                >
+                  <span>${escapeHtml(item.param)}</span>
+                  <span class="cost-item-sort-indicator" aria-hidden="true">${sortDirection === "asc" ? "↑" : sortDirection === "desc" ? "↓" : ""}</span>
+                </button>
+              </td>
               ${cells}
             </tr>
           `;
@@ -550,6 +569,16 @@ function renderCostBreakdownTable() {
         }
 
         renderCostBreakdownTable();
+      });
+    });
+
+  els.costBreakdownBody
+    .querySelectorAll("[data-cost-param]")
+    .forEach((button) => {
+      button.addEventListener("click", () => {
+        const param = button.dataset.costParam;
+        if (!param) return;
+        applyBreakdownSort(param);
       });
     });
 }
@@ -680,6 +709,7 @@ function resetDashboard() {
   state.comparisonData = [];
   state.costBreakdownData = [];
   state.collapsedCostCategories.clear();
+  state.breakdownSort = null;
 
   els.countrySearch.value = "";
   els.citySearch.value = "";
@@ -746,6 +776,53 @@ function formatCostValue(value, options = {}) {
     maximumFractionDigits: fractionDigits,
     minimumFractionDigits: fractionDigits,
   }).format(n);
+}
+
+function applyBreakdownSort(param) {
+  if (!state.comparisonData.length) return;
+
+  const nextDirection =
+    state.breakdownSort?.param === param && state.breakdownSort.direction === "desc"
+      ? "asc"
+      : "desc";
+
+  sortComparisonDataByCostParam(param, nextDirection);
+  state.breakdownSort = { param, direction: nextDirection };
+  state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
+
+  renderComparisonTable();
+  renderCostBreakdownTable();
+}
+
+function sortComparisonDataByCostParam(param, direction) {
+  const multiplier = direction === "asc" ? 1 : -1;
+
+  state.comparisonData = state.comparisonData
+    .map((city, index) => ({
+      city,
+      index,
+      value: getCostParamValue(city, param),
+    }))
+    .sort((a, b) => {
+      const aMissing = a.value == null;
+      const bMissing = b.value == null;
+
+      if (aMissing && bMissing) return a.index - b.index;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+      if (a.value === b.value) return a.index - b.index;
+
+      return (a.value - b.value) * multiplier;
+    })
+    .map((entry) => entry.city);
+}
+
+function getCostParamValue(city, param) {
+  const prices = city.numbeo_cost?.prices;
+  if (!Array.isArray(prices)) return null;
+
+  const entry = prices.find((price) => price?.param === param);
+  return toNumber(entry?.cost);
 }
 
 function escapeHtml(value) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -26,10 +26,7 @@ const els = {
   selectedCitiesLimitHint: document.getElementById("selectedCitiesLimitHint"),
   compareBtn: document.getElementById("compareBtn"),
   resetBtn: document.getElementById("resetBtn"),
-  tableEmptyState: document.getElementById("tableEmptyState"),
   chartEmptyState: document.getElementById("chartEmptyState"),
-  comparisonTableWrapper: document.getElementById("comparisonTableWrapper"),
-  comparisonTableBody: document.querySelector("#comparisonTable tbody"),
   costBreakdownEmptyState: document.getElementById("costBreakdownEmptyState"),
   costBreakdownWrapper: document.getElementById("costBreakdownWrapper"),
   costBreakdownHeadRow: document.getElementById("costBreakdownHeadRow"),
@@ -70,8 +67,8 @@ async function loadInitialData() {
     updateMetrics();
   } catch (error) {
     console.error(error);
-    els.countryList.innerHTML = `<div class="empty-state">Failed to load countries.</div>`;
-    els.cityList.innerHTML = `<div class="empty-state">Failed to load cities.</div>`;
+    els.countryList.innerHTML = `<div class="selection-list-empty">Failed to load countries.</div>`;
+    els.cityList.innerHTML = `<div class="selection-list-empty">Failed to load cities.</div>`;
   }
 }
 
@@ -147,7 +144,7 @@ function renderCountries() {
   });
 
   if (filtered.length === 0) {
-    els.countryList.innerHTML = `<div class="empty-state">No countries found.</div>`;
+    els.countryList.innerHTML = `<div class="selection-list-empty">No countries found.</div>`;
     return;
   }
 
@@ -201,9 +198,9 @@ function renderCities() {
 
   if (filtered.length === 0) {
     if (state.selectedCountryCodes.size === 0) {
-      els.cityList.innerHTML = `<div class="empty-state">Select countries to load cities.</div>`;
+      els.cityList.innerHTML = `<div class="selection-list-empty">Select countries to load cities.</div>`;
     } else {
-      els.cityList.innerHTML = `<div class="empty-state">No cities match the current selection.</div>`;
+      els.cityList.innerHTML = `<div class="selection-list-empty">No cities match the current selection.</div>`;
     }
     return;
   }
@@ -260,11 +257,38 @@ function renderSelectedCountries() {
 
   els.selectedCountries.innerHTML = items
     .map((country) => {
+      const code = country.country_code ?? country.code ?? "";
       const name =
         country.country ?? country.country_name ?? country.name ?? "";
-      return `<span class="chip">${escapeHtml(name)}</span>`;
+      return `
+        <span class="chip chip-dismissible">
+          <span>${escapeHtml(name)}</span>
+          <button
+            type="button"
+            class="chip-remove"
+            data-remove-country="${escapeHtml(code)}"
+            aria-label="Remove ${escapeHtml(name)}"
+          >
+            ×
+          </button>
+        </span>
+      `;
     })
     .join("");
+
+  els.selectedCountries
+    .querySelectorAll("[data-remove-country]")
+    .forEach((button) => {
+      button.addEventListener("click", () => {
+        const code = button.dataset.removeCountry;
+        if (!code) return;
+
+        state.selectedCountryCodes.delete(code);
+        renderCountries();
+        renderSelectedCountries();
+        filterCitiesForSelectedCountries();
+      });
+    });
 }
 
 function renderSelectedCities() {
@@ -279,10 +303,37 @@ function renderSelectedCities() {
 
   els.selectedCities.innerHTML = items
     .map((city) => {
+      const id = String(city.geoname_id ?? city.city_id ?? city.id ?? "");
       const name = city.city ?? city.name ?? "";
-      return `<span class="chip">${escapeHtml(name)}</span>`;
+      return `
+        <span class="chip chip-dismissible">
+          <span>${escapeHtml(name)}</span>
+          <button
+            type="button"
+            class="chip-remove"
+            data-remove-city="${escapeHtml(id)}"
+            aria-label="Remove ${escapeHtml(name)}"
+          >
+            ×
+          </button>
+        </span>
+      `;
     })
     .join("");
+
+  els.selectedCities
+    .querySelectorAll("[data-remove-city]")
+    .forEach((button) => {
+      button.addEventListener("click", () => {
+        const id = button.dataset.removeCity;
+        if (!id) return;
+
+        state.selectedCityIds.delete(id);
+        renderCities();
+        renderSelectedCities();
+        updateMetrics();
+      });
+    });
 }
 
 async function loadComparison() {
@@ -310,7 +361,6 @@ async function loadComparison() {
     state.breakdownSort = null;
     state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
 
-    renderComparisonTable();
     renderCostBreakdownTable();
     renderClimateChart();
     updateMetrics();
@@ -319,39 +369,6 @@ async function loadComparison() {
     console.error(error);
     alert("Failed to load comparison data.");
   }
-}
-
-function renderComparisonTable() {
-  if (!state.comparisonData.length) {
-    els.tableEmptyState.classList.remove("hidden");
-    els.comparisonTableWrapper.classList.add("hidden");
-    return;
-  }
-
-  els.tableEmptyState.classList.add("hidden");
-  els.comparisonTableWrapper.classList.remove("hidden");
-
-  els.comparisonTableBody.innerHTML = state.comparisonData
-    .map((city) => {
-      const cityName = city.city ?? city.name ?? "—";
-      const country =
-        city.country ?? city.country_name ?? city.country_code ?? "—";
-      const idx = city.numbeo_indices ?? {};
-      return `
-        <tr>
-          <td>${escapeHtml(String(cityName))}</td>
-          <td>${escapeHtml(String(country))}</td>
-          <td>${fmt(idx.cost_of_living)}</td>
-          <td>${fmt(idx.rent_index ?? idx.rent)}</td>
-          <td>${fmt(idx.groceries_index ?? idx.groceries)}</td>
-          <td>${fmt(idx.restaurant_price_index ?? idx.restaurant)}</td>
-          <td>${fmt(idx.quality_of_life)}</td>
-          <td>${fmt(idx.safety)}</td>
-          <td>${fmt(idx.health_care)}</td>
-        </tr>
-      `;
-    })
-    .join("");
 }
 
 function renderClimateChart() {
@@ -686,7 +703,6 @@ function resetDashboard() {
   renderCities();
   renderSelectedCountries();
   renderSelectedCities();
-  renderComparisonTable();
   renderCostBreakdownTable();
 
   els.chartEmptyState.classList.remove("hidden");
@@ -758,7 +774,6 @@ function applyBreakdownSort(param) {
   state.breakdownSort = { param, direction: nextDirection };
   state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
 
-  renderComparisonTable();
   renderCostBreakdownTable();
 }
 

--- a/ui/app.js
+++ b/ui/app.js
@@ -8,7 +8,9 @@ const state = {
   costBreakdownData: [],
   collapsedCostCategories: new Set(),
   breakdownSort: null,
-  climateChart: null,
+  climateCharts: [],
+  climateHiddenCities: new Set(),
+  climateHoveredCityKey: null,
 };
 
 const countryDisplayNames = {
@@ -46,11 +48,18 @@ const els = {
   compareBtn: document.getElementById("compareBtn"),
   resetBtn: document.getElementById("resetBtn"),
   chartEmptyState: document.getElementById("chartEmptyState"),
+  climateChartsGrid: document.getElementById("climateChartsGrid"),
   costBreakdownEmptyState: document.getElementById("costBreakdownEmptyState"),
   costBreakdownWrapper: document.getElementById("costBreakdownWrapper"),
   costBreakdownHeadRow: document.getElementById("costBreakdownHeadRow"),
   costBreakdownBody: document.getElementById("costBreakdownBody"),
-  climateCanvas: document.getElementById("climateChart"),
+  climateTemperatureCanvas: document.getElementById("climateTemperatureChart"),
+  climateSunshineCanvas: document.getElementById("climateSunshineChart"),
+  climateDaylightCanvas: document.getElementById("climateDaylightChart"),
+  climateHumidityCanvas: document.getElementById("climateHumidityChart"),
+  climateRainfallCanvas: document.getElementById("climateRainfallChart"),
+  climateWindCanvas: document.getElementById("climateWindChart"),
+  climateUVIndexCanvas: document.getElementById("climateUVIndexChart"),
 };
 
 document.addEventListener("DOMContentLoaded", () => {
@@ -381,6 +390,8 @@ async function loadComparison() {
         ? data.data
         : [];
     state.breakdownSort = null;
+    state.climateHiddenCities.clear();
+    state.climateHoveredCityKey = null;
     state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
 
     renderCostBreakdownTable();
@@ -399,7 +410,6 @@ function renderClimateChart() {
     const bName = (b.city ?? b.name ?? "").toLowerCase();
     return aName.localeCompare(bName);
   });
-  const datasets = [];
   const labels = [
     "Jan",
     "Feb",
@@ -414,64 +424,149 @@ function renderClimateChart() {
     "Nov",
     "Dec",
   ];
+  const climateCities = chartCities.map((city, index) =>
+    buildClimateCityConfig(city, index),
+  );
 
-  for (const city of chartCities) {
-    const climate = city.avg_climate ?? {};
-    const highTemp =
-      climate.high_temp ?? climate.high_temps ?? climate.avg_high_temp ?? [];
-
-    if (Array.isArray(highTemp) && highTemp.length > 0) {
-      datasets.push({
-        label: city.city ?? city.name ?? "City",
-        data: normalizeMonthlySeries(highTemp),
-        tension: 0.3,
-      });
-    }
-  }
-
-  if (datasets.length === 0) {
+  if (climateCities.length === 0) {
     els.chartEmptyState.classList.remove("hidden");
-    if (state.climateChart) {
-      state.climateChart.destroy();
-      state.climateChart = null;
-    }
+    els.climateChartsGrid.classList.add("hidden");
+    destroyClimateCharts();
     return;
   }
 
   els.chartEmptyState.classList.add("hidden");
+  els.climateChartsGrid.classList.remove("hidden");
 
-  if (state.climateChart) {
-    state.climateChart.destroy();
-  }
+  destroyClimateCharts();
 
-  state.climateChart = new Chart(els.climateCanvas, {
-    type: "line",
-    data: {
-      labels,
-      datasets,
-    },
-    options: {
-      responsive: true,
-      maintainAspectRatio: false,
-      interaction: {
-        mode: "nearest",
-        intersect: false,
-      },
-      plugins: {
-        legend: {
-          position: "top",
-        },
-      },
-      scales: {
-        y: {
-          title: {
-            display: true,
-            text: "Temperature",
-          },
-        },
-      },
-    },
-  });
+  state.climateCharts = [
+    new Chart(
+      els.climateTemperatureCanvas,
+      buildClimateChartConfig({
+        chartKey: "temperature",
+        labels,
+        datasets: climateCities.flatMap((city) => [
+          buildClimateDataset(city, "high_temp", {
+            datasetLabel: `${city.name} high`,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+            borderDash: [],
+            variant: "high",
+          }),
+          buildClimateDataset(city, "low_temp", {
+            datasetLabel: `${city.name} low`,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+            borderDash: [8, 5],
+            variant: "low",
+          }),
+        ]),
+        yTitle: "°C",
+        showLegend: true,
+      }),
+    ),
+    new Chart(
+      els.climateSunshineCanvas,
+      buildClimateChartConfig({
+        chartKey: "sunshine",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "sunshine", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "Hours",
+      }),
+    ),
+    new Chart(
+      els.climateDaylightCanvas,
+      buildClimateChartConfig({
+        chartKey: "daylight",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "daylight", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "Hours",
+      }),
+    ),
+    new Chart(
+      els.climateHumidityCanvas,
+      buildClimateChartConfig({
+        chartKey: "humidity",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "humidity", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "%",
+      }),
+    ),
+    new Chart(
+      els.climateRainfallCanvas,
+      buildClimateChartConfig({
+        chartKey: "rainfall",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "rainfall", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "mm",
+      }),
+    ),
+    new Chart(
+      els.climateWindCanvas,
+      buildClimateChartConfig({
+        chartKey: "wind",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "wind_speed", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "km/h",
+      }),
+    ),
+    new Chart(
+      els.climateUVIndexCanvas,
+      buildClimateChartConfig({
+        chartKey: "uv_index",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "uv_index", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "UV",
+      }),
+    ),
+  ];
+
+  syncClimateChartStyles();
 }
 
 function renderCostBreakdownTable() {
@@ -746,6 +841,8 @@ function resetDashboard() {
   state.costBreakdownData = [];
   state.collapsedCostCategories.clear();
   state.breakdownSort = null;
+  state.climateHiddenCities.clear();
+  state.climateHoveredCityKey = null;
 
   els.countrySearch.value = "";
   els.citySearch.value = "";
@@ -757,10 +854,8 @@ function resetDashboard() {
   renderCostBreakdownTable();
 
   els.chartEmptyState.classList.remove("hidden");
-  if (state.climateChart) {
-    state.climateChart.destroy();
-    state.climateChart = null;
-  }
+  els.climateChartsGrid.classList.add("hidden");
+  destroyClimateCharts();
 
   updateMetrics();
   expandFilters();
@@ -786,6 +881,356 @@ function normalizeMonthlySeries(arr) {
     out[i] = toNumber(arr[i]);
   }
   return out;
+}
+
+function buildClimateCityConfig(city, index) {
+  const climate = city.avg_climate ?? buildPlaceholderClimate(city, index);
+  const key = String(city.geoname_id ?? city.city_id ?? city.id ?? city.city ?? index);
+  return {
+    key,
+    name: city.city ?? city.name ?? `City ${index + 1}`,
+    climate,
+    color: getClimateColor(index),
+  };
+}
+
+function buildPlaceholderClimate(city, index) {
+  const offset = index * 1.4;
+  return {
+    high_temp: [5, 7, 11, 16, 21, 25, 28, 28, 23, 17, 11, 7].map((v) => v + offset),
+    low_temp: [-1, 0, 3, 8, 13, 17, 20, 20, 16, 10, 5, 1].map((v) => v + offset),
+    sunshine: [3, 4, 5, 7, 8, 9, 10, 9, 7, 5, 4, 3].map((v) => Math.max(0, v - index * 0.2)),
+    daylight: [9, 10, 12, 13, 15, 16, 15, 14, 12, 11, 9, 8].map((v) => v),
+    humidity: [76, 74, 71, 69, 68, 66, 64, 65, 68, 72, 75, 77].map((v) => v + index),
+    rainfall: [62, 58, 61, 67, 72, 76, 81, 79, 70, 66, 64, 68].map((v) => v + index * 4),
+    wind_speed: [14, 13, 13, 12, 11, 10, 9, 9, 10, 11, 12, 13].map((v) => Math.max(3, v - index * 0.3)),
+    uv_index: [1, 2, 3, 5, 6, 7, 8, 7, 5, 3, 2, 1].map((v) => Math.min(11, Math.max(0, v + index * 0.2))),
+  };
+}
+
+function getClimateColor(index) {
+  const palette = [
+    "#2563eb",
+    "#ef4444",
+    "#0f766e",
+    "#d97706",
+    "#7c3aed",
+    "#db2777",
+    "#0891b2",
+    "#65a30d",
+    "#c2410c",
+    "#475569",
+    "#16a34a",
+    "#ea580c",
+    "#4f46e5",
+    "#be123c",
+    "#0d9488",
+  ];
+  return palette[index % palette.length];
+}
+
+function buildClimateDataset(city, metricKey, options = {}) {
+  const rawSeries = city.climate?.[metricKey] ?? [];
+  const baseColor = options.color ?? city.color;
+  return {
+    label: options.datasetLabel ?? city.name,
+    data: normalizeMonthlySeries(rawSeries),
+    borderColor: baseColor,
+    backgroundColor: withAlpha(baseColor, 0.12),
+    borderWidth: 2.5,
+    tension: 0.35,
+    pointRadius: 0,
+    pointHoverRadius: 4,
+    pointHitRadius: 14,
+    fill: false,
+    borderDash: options.borderDash ?? [],
+    cityKey: options.cityKey ?? city.key,
+    cityLabel: options.cityLabel ?? city.name,
+    variant: options.variant ?? "default",
+    _baseColor: baseColor,
+  };
+}
+
+function buildClimateChartConfig({
+  chartKey,
+  labels,
+  datasets,
+  yTitle,
+  showLegend = false,
+}) {
+  return {
+    type: "line",
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        mode: "nearest",
+        intersect: false,
+      },
+      onHover: (_event, elements, chart) => {
+        const hoveredDataset = elements.length > 0
+          ? chart.data.datasets[elements[0].datasetIndex]
+          : null;
+        setHoveredClimateCity(hoveredDataset?.cityKey ?? null);
+      },
+      plugins: {
+        legend: showLegend
+          ? {
+              position: "top",
+              labels: {
+                usePointStyle: true,
+                pointStyle: "circle",
+                boxWidth: 10,
+                boxHeight: 10,
+                padding: 14,
+                font: {
+                  size: 13,
+                  lineHeight: 1.15,
+                },
+                generateLabels: (chart) => {
+                  const seen = new Set();
+                  const labels = [];
+                  chart.data.datasets.forEach((dataset, datasetIndex) => {
+                    if (seen.has(dataset.cityKey)) return;
+                    seen.add(dataset.cityKey);
+                    const isHidden = state.climateHiddenCities.has(dataset.cityKey);
+                    labels.push({
+                      text: dataset.cityLabel,
+                      fillStyle: withAlpha(dataset._baseColor, isHidden ? 0.18 : 0.9),
+                      strokeStyle: withAlpha(dataset._baseColor, isHidden ? 0.18 : 0.9),
+                      lineWidth: 2,
+                      hidden: isHidden,
+                      datasetIndex,
+                      cityKey: dataset.cityKey,
+                    });
+                  });
+                  return labels;
+                },
+              },
+              onClick: (_event, legendItem) => {
+                const cityKey = legendItem.cityKey;
+                if (!cityKey) return;
+                if (state.climateHiddenCities.has(cityKey)) {
+                  state.climateHiddenCities.delete(cityKey);
+                } else {
+                  state.climateHiddenCities.add(cityKey);
+                }
+                syncClimateChartStyles();
+              },
+            }
+          : {
+              display: false,
+            },
+        tooltip: {
+          enabled: false,
+          mode: "nearest",
+          intersect: false,
+          external: (context) =>
+            renderClimateTooltip(context, { chartKey, yTitle }),
+        },
+      },
+      scales: {
+        x: {
+          grid: {
+            color: "rgba(148, 163, 184, 0.12)",
+          },
+          ticks: {
+            color: "#64748b",
+          },
+        },
+        y: {
+          grid: {
+            color: "rgba(148, 163, 184, 0.12)",
+          },
+          ticks: {
+            color: "#64748b",
+          },
+          title: {
+            display: true,
+            text: yTitle,
+            color: "#64748b",
+            font: {
+              size: 12,
+              weight: "600",
+            },
+          },
+        },
+      },
+      elements: {
+        line: {
+          capBezierPoints: true,
+        },
+      },
+    },
+    plugins: [
+      {
+        id: `climate-hover-reset-${chartKey}`,
+        afterEvent: (_chart, args) => {
+          if (args.event.type === "mouseout") {
+            setHoveredClimateCity(null);
+          }
+        },
+      },
+    ],
+  };
+}
+
+function destroyClimateCharts() {
+  state.climateCharts.forEach((chart) => chart.destroy());
+  state.climateCharts = [];
+}
+
+function setHoveredClimateCity(cityKey) {
+  if (state.climateHoveredCityKey === cityKey) return;
+  state.climateHoveredCityKey = cityKey;
+  syncClimateChartStyles();
+}
+
+function syncClimateChartStyles() {
+  state.climateCharts.forEach((chart) => {
+    chart.data.datasets.forEach((dataset) => {
+      const isHidden = state.climateHiddenCities.has(dataset.cityKey);
+      const isHovered =
+        state.climateHoveredCityKey &&
+        state.climateHoveredCityKey === dataset.cityKey;
+      const shouldFade =
+        state.climateHoveredCityKey && !isHovered;
+      const baseColor = getBaseDatasetColor(dataset);
+      const isLowVariant = dataset.variant === "low";
+      const alpha = isHidden
+        ? 0.06
+        : shouldFade
+          ? isLowVariant ? 0.18 : 0.3
+          : isHovered
+            ? isLowVariant ? 0.86 : 1
+            : isLowVariant ? 0.5 : 0.76;
+
+      dataset.hidden = isHidden;
+      dataset.borderColor = withAlpha(baseColor, alpha);
+      dataset.backgroundColor = withAlpha(
+        baseColor,
+        isHidden ? 0.03 : shouldFade ? 0.05 : isLowVariant ? 0.08 : 0.15,
+      );
+      dataset.borderWidth = isHovered
+        ? isLowVariant ? 2.3 : 3.3
+        : isLowVariant ? 1.7 : 2.2;
+      dataset.pointRadius = isHovered ? 2.5 : 0;
+    });
+    chart.update("none");
+  });
+}
+
+function renderClimateTooltip(context, options) {
+  const { chart, tooltip } = context;
+  const tooltipEl = getClimateTooltipElement(chart);
+
+  if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
+    tooltipEl.classList.remove("is-visible");
+    return;
+  }
+
+  const dataPoint = tooltip.dataPoints[0];
+  const dataset = dataPoint.dataset;
+  const cityKey = dataset.cityKey;
+  const cityLabel = dataset.cityLabel;
+  const monthLabel = dataPoint.label;
+  const color = dataset._baseColor ?? "#2563eb";
+
+  let contentHtml = "";
+  if (options.chartKey === "temperature") {
+    const highDataset = chart.data.datasets.find(
+      (item) => item.cityKey === cityKey && item.variant === "high",
+    );
+    const lowDataset = chart.data.datasets.find(
+      (item) => item.cityKey === cityKey && item.variant === "low",
+    );
+    const highValue = toNumber(highDataset?.data?.[dataPoint.dataIndex]);
+    const lowValue = toNumber(lowDataset?.data?.[dataPoint.dataIndex]);
+    contentHtml = `
+      <div class="chart-tooltip-city">${escapeHtml(cityLabel)}</div>
+      <div class="chart-tooltip-text">${escapeHtml(monthLabel)}:</div>
+      <div class="chart-tooltip-metric">
+        <span class="chart-tooltip-key">High:</span>
+        <span class="chart-tooltip-value">${escapeHtml(formatTooltipValue(highValue, "°C"))}</span>
+      </div>
+      <div class="chart-tooltip-metric">
+        <span class="chart-tooltip-key">Low:</span>
+        <span class="chart-tooltip-value">${escapeHtml(formatTooltipValue(lowValue, "°C"))}</span>
+      </div>
+    `;
+  } else {
+    const value = toNumber(dataPoint.parsed?.y);
+    contentHtml = `
+      <div class="chart-tooltip-city">${escapeHtml(cityLabel)}</div>
+      <div class="chart-tooltip-text">${escapeHtml(monthLabel)}: ${escapeHtml(formatTooltipValue(value, options.yTitle))}</div>
+    `;
+  }
+
+  tooltipEl.innerHTML = `
+    <div class="chart-tooltip-row">
+      <span class="chart-tooltip-swatch" style="background:${escapeHtml(color)}"></span>
+      <div>${contentHtml}</div>
+    </div>
+  `;
+
+  const { offsetLeft: positionX, offsetTop: positionY } = chart.canvas;
+  tooltipEl.style.left = `${positionX + tooltip.caretX + 14}px`;
+  tooltipEl.style.top = `${positionY + tooltip.caretY - 12}px`;
+  tooltipEl.classList.add("is-visible");
+}
+
+function getClimateTooltipElement(chart) {
+  const parent = chart.canvas.parentNode;
+  let tooltipEl = parent.querySelector(".chart-tooltip");
+
+  if (!tooltipEl) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "chart-tooltip";
+    parent.appendChild(tooltipEl);
+  }
+
+  return tooltipEl;
+}
+
+function formatTooltipValue(value, unit) {
+  if (value == null) return "—";
+  const raw = String(value);
+  if (unit === "%" || unit === "mm") {
+    return `${raw}${unit}`;
+  }
+  if (unit === "km/h") {
+    return `${raw} km/h`;
+  }
+  if (unit === "UV") {
+    return raw;
+  }
+  if (unit === "Hours") {
+    return `${raw} h`;
+  }
+  if (unit === "°C") {
+    return `${raw}${unit}`;
+  }
+  return `${raw} ${unit}`;
+}
+
+function getBaseDatasetColor(dataset) {
+  return dataset._baseColor ?? "#2563eb";
+}
+
+function withAlpha(color, alpha) {
+  const hex = color.replace("#", "");
+  const normalized =
+    hex.length === 3
+      ? hex
+          .split("")
+          .map((char) => char + char)
+          .join("")
+      : hex;
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
 function toNumber(value) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -11,6 +11,7 @@ const state = {
   breakdownSort: null,
   indicesSort: null,
   countryIndicesSort: null,
+  legatumIndicesSort: null,
   climateCharts: [],
   climateHiddenCities: new Set(),
   climateHoveredCityKey: null,
@@ -55,6 +56,21 @@ const countryNumbeoIndexRows = [
   { key: "avg_salary_usd", label: "Average Salary (USD)", better: "high", format: "currency" },
 ];
 
+const legatumIndexRows = [
+  { key: "safety_and_security", label: "Safety and Security", better: "high" },
+  { key: "personal_freedom", label: "Personal Freedom", better: "high" },
+  { key: "governance", label: "Governance", better: "high" },
+  { key: "social_capital", label: "Social Capital", better: "high" },
+  { key: "investment_invironment", label: "Investment Invironment", better: "high" },
+  { key: "enterprise_conditions", label: "Enterprise Conditions", better: "high" },
+  { key: "infrastructure_and_market_access", label: "Infrastructure and Market Access", better: "high" },
+  { key: "economic_quality", label: "Economic Quality", better: "high" },
+  { key: "living_conditions", label: "Living Conditions", better: "high" },
+  { key: "health", label: "Health", better: "high" },
+  { key: "education", label: "Education", better: "high" },
+  { key: "natural_environment", label: "Natural Environment", better: "high" },
+];
+
 const els = {
   filtersCard: document.querySelector(".filters-card"),
   filtersBody: document.getElementById("filtersBody"),
@@ -84,6 +100,10 @@ const els = {
   countryNumbeoIndicesWrapper: document.getElementById("countryNumbeoIndicesWrapper"),
   countryNumbeoIndicesHeadRow: document.getElementById("countryNumbeoIndicesHeadRow"),
   countryNumbeoIndicesBody: document.getElementById("countryNumbeoIndicesBody"),
+  legatumIndicesEmptyState: document.getElementById("legatumIndicesEmptyState"),
+  legatumIndicesWrapper: document.getElementById("legatumIndicesWrapper"),
+  legatumIndicesHeadRow: document.getElementById("legatumIndicesHeadRow"),
+  legatumIndicesBody: document.getElementById("legatumIndicesBody"),
   climateTemperatureCanvas: document.getElementById("climateTemperatureChart"),
   climateSunshineCanvas: document.getElementById("climateSunshineChart"),
   climateDaylightCanvas: document.getElementById("climateDaylightChart"),
@@ -432,6 +452,7 @@ async function loadComparison() {
     renderClimateChart();
     renderNumbeoIndicesTable();
     renderCountryNumbeoIndicesTable();
+    renderLegatumIndicesTable();
     updateMetrics();
     collapseFilters();
   } catch (error) {
@@ -821,10 +842,34 @@ function renderCountryNumbeoIndicesTable() {
     keyDataAttr: "data-country-index-key",
     applySort: applyCountryIndicesSort,
     getColumnLabel: (country) =>
-      country.country ?? country.country_name ?? country.country_code ?? "Country",
+      getDisplayCountryName(
+        country.country ?? country.country_name ?? country.country_code ?? "Country",
+      ),
     getColumnMeta: () => "",
     getColumnMetaTitle: () => "",
     getValue: (country, key) => toNumber(country.numbeo_indices?.[key]),
+  });
+}
+
+function renderLegatumIndicesTable() {
+  renderNumbeoIndicesTableSection({
+    data: state.countryComparisonData,
+    emptyStateEl: els.legatumIndicesEmptyState,
+    wrapperEl: els.legatumIndicesWrapper,
+    headRowEl: els.legatumIndicesHeadRow,
+    bodyEl: els.legatumIndicesBody,
+    headLabel: "Index",
+    rows: legatumIndexRows,
+    sortState: state.legatumIndicesSort,
+    keyDataAttr: "data-legatum-index-key",
+    applySort: applyLegatumIndicesSort,
+    getColumnLabel: (country) =>
+      getDisplayCountryName(
+        country.country ?? country.country_name ?? country.country_code ?? "Country",
+      ),
+    getColumnMeta: () => "",
+    getColumnMetaTitle: () => "",
+    getValue: (country, key) => toNumber(country.legatum_indices?.[key]?.score_2023),
   });
 }
 
@@ -1072,6 +1117,7 @@ function resetDashboard() {
   state.breakdownSort = null;
   state.indicesSort = null;
   state.countryIndicesSort = null;
+  state.legatumIndicesSort = null;
   state.climateHiddenCities.clear();
   state.climateHoveredCityKey = null;
 
@@ -1085,6 +1131,7 @@ function resetDashboard() {
   renderCostBreakdownTable();
   renderNumbeoIndicesTable();
   renderCountryNumbeoIndicesTable();
+  renderLegatumIndicesTable();
 
   els.chartEmptyState.classList.remove("hidden");
   els.climateChartsGrid.classList.add("hidden");
@@ -1554,8 +1601,27 @@ function applyCountryIndicesSort(key) {
 
   sortCountryComparisonDataByIndexKey(key, nextDirection);
   state.countryIndicesSort = { key, direction: nextDirection };
+  state.legatumIndicesSort = null;
 
   renderCountryNumbeoIndicesTable();
+  renderLegatumIndicesTable();
+}
+
+function applyLegatumIndicesSort(key) {
+  if (!state.countryComparisonData.length) return;
+
+  const nextDirection =
+    state.legatumIndicesSort?.key === key &&
+    state.legatumIndicesSort.direction === "desc"
+      ? "asc"
+      : "desc";
+
+  sortCountryComparisonDataByLegatumKey(key, nextDirection);
+  state.legatumIndicesSort = { key, direction: nextDirection };
+  state.countryIndicesSort = null;
+
+  renderCountryNumbeoIndicesTable();
+  renderLegatumIndicesTable();
 }
 
 function applyLoadedComparisonSelection() {
@@ -1572,9 +1638,11 @@ function applyLoadedComparisonSelection() {
     state.breakdownSort = null;
     state.indicesSort = null;
     state.countryIndicesSort = null;
+    state.legatumIndicesSort = null;
     renderCostBreakdownTable();
     renderNumbeoIndicesTable();
     renderCountryNumbeoIndicesTable();
+    renderLegatumIndicesTable();
     renderClimateChart();
     return;
   }
@@ -1584,6 +1652,7 @@ function applyLoadedComparisonSelection() {
   renderCostBreakdownTable();
   renderNumbeoIndicesTable();
   renderCountryNumbeoIndicesTable();
+  renderLegatumIndicesTable();
   renderClimateChart();
 }
 
@@ -1641,6 +1710,29 @@ function sortCountryComparisonDataByIndexKey(key, direction) {
       country,
       index,
       value: toNumber(country.numbeo_indices?.[key]),
+    }))
+    .sort((a, b) => {
+      const aMissing = a.value == null;
+      const bMissing = b.value == null;
+
+      if (aMissing && bMissing) return a.index - b.index;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+      if (a.value === b.value) return a.index - b.index;
+
+      return (a.value - b.value) * multiplier;
+    })
+    .map((entry) => entry.country);
+}
+
+function sortCountryComparisonDataByLegatumKey(key, direction) {
+  const multiplier = direction === "asc" ? 1 : -1;
+
+  state.countryComparisonData = state.countryComparisonData
+    .map((country, index) => ({
+      country,
+      index,
+      value: toNumber(country.legatum_indices?.[key]?.score_2023),
     }))
     .sort((a, b) => {
       const aMissing = a.value == null;

--- a/ui/app.js
+++ b/ui/app.js
@@ -72,6 +72,8 @@ const legatumIndexRows = [
   { key: "natural_environment", label: "Natural Environment", better: "high" },
 ];
 
+const legatumYears = Array.from({ length: 17 }, (_, index) => 2007 + index);
+
 const els = {
   filtersCard: document.querySelector(".filters-card"),
   filtersBody: document.getElementById("filtersBody"),
@@ -888,7 +890,10 @@ function renderLegatumIndicesTable() {
           isRankMode ? "rank_2023" : "score_2023"
         ],
       ),
+    getCellDataAttrs: (country, row) =>
+      `data-legatum-row-key="${escapeHtml(row.key)}" data-legatum-country-code="${escapeHtml(String(country.country_code ?? ""))}"`,
   });
+  bindLegatumTooltipEvents();
   syncLegatumToggleButtons();
 }
 
@@ -907,6 +912,7 @@ function renderNumbeoIndicesTableSection({
   getColumnMeta,
   getColumnMetaTitle,
   getValue,
+  getCellDataAttrs = null,
 }) {
   if (!data.length) {
     emptyStateEl.classList.remove("hidden");
@@ -964,6 +970,9 @@ function renderNumbeoIndicesTableSection({
       const cells = data
         .map((item) => {
           const value = getValue(item, row.key);
+          const cellDataAttrs = getCellDataAttrs
+            ? getCellDataAttrs(item, row)
+            : "";
           let cellClass = "indices-value";
 
           if (
@@ -1009,7 +1018,7 @@ function renderNumbeoIndicesTableSection({
             }
           }
 
-          return `<td class="${cellClass}">${escapeHtml(formatIndexValue(value, row))}</td>`;
+          return `<td class="${cellClass}" ${cellDataAttrs}>${escapeHtml(formatIndexValue(value, row))}</td>`;
         })
         .join("");
 
@@ -1525,6 +1534,165 @@ function formatIndexValue(value, row = null) {
     }).format(value);
   }
   return String(value);
+}
+
+function bindLegatumTooltipEvents() {
+  els.legatumIndicesBody
+    .querySelectorAll("[data-legatum-row-key][data-legatum-country-code]")
+    .forEach((cell) => {
+      cell.addEventListener("mouseenter", () => {
+        showLegatumTooltip(cell);
+      });
+      cell.addEventListener("mousemove", (event) => {
+        positionLegatumTooltip(event.clientX, event.clientY);
+      });
+      cell.addEventListener("mouseleave", hideLegatumTooltip);
+    });
+}
+
+function showLegatumTooltip(cell) {
+  const rowKey = cell.dataset.legatumRowKey;
+  const countryCode = cell.dataset.legatumCountryCode;
+  if (!rowKey || !countryCode) return;
+
+  const country = state.countryComparisonData.find(
+    (item) => item.country_code === countryCode,
+  );
+  const row = legatumIndexRows.find((item) => item.key === rowKey);
+  if (!country || !row) return;
+
+  const tooltipEl = getLegatumTooltipElement();
+  const isRankMode = state.legatumMetricMode === "rank";
+  const series = buildLegatumSeries(
+    country.legatum_indices?.[rowKey],
+    isRankMode ? "rank" : "score",
+  );
+  if (!series.length) {
+    tooltipEl.classList.remove("is-visible");
+    return;
+  }
+
+  const values = series.map((point) => point.value);
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+  const currentPoint = series[series.length - 1];
+  const displayCountry = getDisplayCountryName(
+    country.country ?? country.country_name ?? country.country_code ?? countryCode,
+  );
+
+  tooltipEl.innerHTML = `
+    <div class="legatum-tooltip-title">${escapeHtml(displayCountry)}</div>
+    <div class="legatum-tooltip-subtitle">${escapeHtml(row.label)} • ${escapeHtml(isRankMode ? "Rank" : "Score")}</div>
+    <div class="legatum-tooltip-current">${escapeHtml(String(currentPoint.year))}: ${escapeHtml(String(currentPoint.value))}</div>
+    <div class="legatum-tooltip-chart">
+      ${renderLegatumSparkline(series, { minValue, maxValue, isRankMode })}
+    </div>
+  `;
+  tooltipEl.classList.add("is-visible");
+}
+
+function hideLegatumTooltip() {
+  getLegatumTooltipElement().classList.remove("is-visible");
+}
+
+function positionLegatumTooltip(clientX, clientY) {
+  const tooltipEl = getLegatumTooltipElement();
+  if (!tooltipEl.classList.contains("is-visible")) return;
+
+  const offset = 16;
+  const { innerWidth, innerHeight } = window;
+  const rect = tooltipEl.getBoundingClientRect();
+  let left = clientX + offset;
+  let top = clientY + offset;
+
+  if (left + rect.width > innerWidth - 12) {
+    left = clientX - rect.width - offset;
+  }
+  if (top + rect.height > innerHeight - 12) {
+    top = clientY - rect.height - offset;
+  }
+
+  tooltipEl.style.left = `${Math.max(12, left)}px`;
+  tooltipEl.style.top = `${Math.max(12, top)}px`;
+}
+
+function getLegatumTooltipElement() {
+  let tooltipEl = document.querySelector(".legatum-tooltip");
+  if (!tooltipEl) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "legatum-tooltip";
+    document.body.appendChild(tooltipEl);
+  }
+  return tooltipEl;
+}
+
+function buildLegatumSeries(entry, mode) {
+  if (!entry) return [];
+
+  return legatumYears
+    .map((year) => ({
+      year,
+      value: toNumber(entry[`${mode}_${year}`]),
+    }))
+    .filter((point) => point.value != null);
+}
+
+function renderLegatumSparkline(series, { minValue, maxValue, isRankMode }) {
+  const width = 230;
+  const height = 122;
+  const padding = { top: 10, right: 30, bottom: 24, left: 8 };
+  const plotWidth = width - padding.left - padding.right;
+  const plotHeight = height - padding.top - padding.bottom;
+  const range = maxValue - minValue || 1;
+  const midYear = 2015;
+  const midX =
+    padding.left +
+    (plotWidth * (midYear - legatumYears[0])) /
+      Math.max(1, legatumYears.length - 1);
+  const midValue = (minValue + maxValue) / 2;
+  const midNormalized = isRankMode
+    ? (maxValue - midValue) / range
+    : (midValue - minValue) / range;
+  const midY = padding.top + plotHeight - midNormalized * plotHeight;
+
+  const points = series.map((point, index) => {
+    const x =
+      padding.left +
+      (plotWidth * index) / Math.max(1, series.length - 1);
+    const normalized = isRankMode
+      ? (maxValue - point.value) / range
+      : (point.value - minValue) / range;
+    const y = padding.top + plotHeight - normalized * plotHeight;
+    return { ...point, x, y };
+  });
+
+  const polylinePoints = points.map((point) => `${point.x},${point.y}`).join(" ");
+  const stroke = isRankMode ? "#2563eb" : "#0f766e";
+  const topAxisValue = isRankMode ? minValue : maxValue;
+  const bottomAxisValue = isRankMode ? maxValue : minValue;
+
+  return `
+    <svg viewBox="0 0 ${width} ${height}" class="legatum-tooltip-sparkline" aria-hidden="true">
+      <line x1="${padding.left}" y1="${padding.top}" x2="${width - padding.right}" y2="${padding.top}" class="legatum-tooltip-grid" />
+      <line x1="${padding.left}" y1="${midY}" x2="${width - padding.right}" y2="${midY}" class="legatum-tooltip-grid legatum-tooltip-grid-mid" />
+      <line x1="${padding.left}" y1="${padding.top + plotHeight}" x2="${width - padding.right}" y2="${padding.top + plotHeight}" class="legatum-tooltip-grid" />
+      <line x1="${midX}" y1="${padding.top + plotHeight}" x2="${midX}" y2="${padding.top + plotHeight + 5}" class="legatum-tooltip-axis-tick legatum-tooltip-axis-tick-mid" />
+      <polyline points="${polylinePoints}" fill="none" stroke="${stroke}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+      <circle cx="${points[0].x}" cy="${points[0].y}" r="2.5" fill="${stroke}" />
+      <circle cx="${points[points.length - 1].x}" cy="${points[points.length - 1].y}" r="3" fill="${stroke}" />
+      <text x="${width - 2}" y="${padding.top + 4}" text-anchor="end" class="legatum-tooltip-y-label">${escapeHtml(String(topAxisValue))}</text>
+      <text x="${width - 2}" y="${midY + 3}" text-anchor="end" class="legatum-tooltip-y-label legatum-tooltip-y-label-mid">${escapeHtml(formatLegatumAxisMidValue(midValue))}</text>
+      <text x="${width - 2}" y="${padding.top + plotHeight}" text-anchor="end" dominant-baseline="ideographic" class="legatum-tooltip-y-label">${escapeHtml(String(bottomAxisValue))}</text>
+      <text x="${padding.left}" y="${height - 4}" text-anchor="start" class="legatum-tooltip-x-label">2007</text>
+      <text x="${midX}" y="${height - 4}" text-anchor="middle" class="legatum-tooltip-x-label legatum-tooltip-x-label-mid">2015</text>
+      <text x="${width - padding.right}" y="${height - 4}" text-anchor="end" class="legatum-tooltip-x-label">2023</text>
+    </svg>
+  `;
+}
+
+function formatLegatumAxisMidValue(value) {
+  if (!Number.isFinite(value)) return "—";
+  return String(Math.round(value));
 }
 
 function getBaseDatasetColor(dataset) {

--- a/ui/app.js
+++ b/ui/app.js
@@ -8,6 +8,7 @@ const state = {
   costBreakdownData: [],
   collapsedCostCategories: new Set(),
   breakdownSort: null,
+  indicesSort: null,
   climateCharts: [],
   climateHiddenCities: new Set(),
   climateHoveredCityKey: null,
@@ -32,6 +33,21 @@ const countryDisplayNames = {
   "Venezuela, Bolivarian Republic of": "Venezuela",
 };
 
+const numbeoIndexRows = [
+  { key: "quality_of_life", label: "Quality of Life", better: "high" },
+  { key: "safety", label: "Safety", better: "high" },
+  { key: "health_care", label: "Health Care", better: "high" },
+  { key: "climate", label: "Climate", better: "high" },
+  { key: "local_purchasing_power", label: "Local Purchasing Power", better: "high" },
+  { key: "cost_of_living", label: "Cost of Living", better: "low" },
+  { key: "rent", label: "Rent", better: "low" },
+  { key: "cost_of_living_plus_rent", label: "Cost of Living Plus Rent", better: "low" },
+  { key: "groceries", label: "Groceries", better: "low" },
+  { key: "property_price_to_income_ratio", label: "Property Price to Income Ratio", better: "low" },
+  { key: "traffic_commute_time", label: "Traffic Commute Time", better: "low" },
+  { key: "pollution", label: "Pollution", better: "low" },
+];
+
 const els = {
   filtersCard: document.querySelector(".filters-card"),
   filtersBody: document.getElementById("filtersBody"),
@@ -53,6 +69,10 @@ const els = {
   costBreakdownWrapper: document.getElementById("costBreakdownWrapper"),
   costBreakdownHeadRow: document.getElementById("costBreakdownHeadRow"),
   costBreakdownBody: document.getElementById("costBreakdownBody"),
+  numbeoIndicesEmptyState: document.getElementById("numbeoIndicesEmptyState"),
+  numbeoIndicesWrapper: document.getElementById("numbeoIndicesWrapper"),
+  numbeoIndicesHeadRow: document.getElementById("numbeoIndicesHeadRow"),
+  numbeoIndicesBody: document.getElementById("numbeoIndicesBody"),
   climateTemperatureCanvas: document.getElementById("climateTemperatureChart"),
   climateSunshineCanvas: document.getElementById("climateSunshineChart"),
   climateDaylightCanvas: document.getElementById("climateDaylightChart"),
@@ -396,6 +416,7 @@ async function loadComparison() {
 
     renderCostBreakdownTable();
     renderClimateChart();
+    renderNumbeoIndicesTable();
     updateMetrics();
     collapseFilters();
   } catch (error) {
@@ -620,7 +641,7 @@ function renderCostBreakdownTable() {
           const maxValue =
             numericValues.length > 0 ? Math.max(...numericValues) : null;
           const shouldApplySecondary =
-            item.values.length - numericValues.length <= 1 &&
+            item.values.length - numericValues.length < 5 &&
             numericValues.length >= 3;
           const sortedUniqueValues = shouldApplySecondary
             ? Array.from(new Set(numericValues)).sort((a, b) => a - b)
@@ -749,6 +770,140 @@ function renderCostBreakdownTable() {
     });
 }
 
+function renderNumbeoIndicesTable() {
+  if (!state.comparisonData.length) {
+    els.numbeoIndicesEmptyState.classList.remove("hidden");
+    els.numbeoIndicesWrapper.classList.add("hidden");
+    return;
+  }
+
+  els.numbeoIndicesEmptyState.classList.add("hidden");
+  els.numbeoIndicesWrapper.classList.remove("hidden");
+
+  els.numbeoIndicesHeadRow.innerHTML = `
+    <th>Index</th>
+    ${state.comparisonData
+      .map((city) => {
+        const cityName = city.city ?? city.name ?? "City";
+        const country =
+          city.country ?? city.country_name ?? city.country_code ?? "";
+        const displayCountry = getDisplayCountryName(country);
+        return `<th><span class="table-city-name" title="${escapeHtml(String(cityName))}">${escapeHtml(cityName)}</span><br><span class="table-city-meta" title="${escapeHtml(String(country))}">${escapeHtml(String(displayCountry))}</span></th>`;
+      })
+      .join("")}
+  `;
+
+  els.numbeoIndicesBody.innerHTML = numbeoIndexRows
+    .map((row) => {
+      const isHigherBetter = row.better === "high";
+      const isActiveSort = state.indicesSort?.key === row.key;
+      const sortDirection = isActiveSort ? state.indicesSort.direction : null;
+      const numericEntries = state.comparisonData
+        .map((city, index) => ({
+          index,
+          numericValue: toNumber(city.numbeo_indices?.[row.key]),
+        }))
+        .filter((entry) => entry.numericValue != null);
+      const numericValues = numericEntries.map((entry) => entry.numericValue);
+      const minValue =
+        numericValues.length > 0 ? Math.min(...numericValues) : null;
+      const maxValue =
+        numericValues.length > 0 ? Math.max(...numericValues) : null;
+      const shouldApplySecondary =
+        state.comparisonData.length - numericValues.length < 5 &&
+        numericValues.length >= 3;
+      const sortedUniqueValues = shouldApplySecondary
+        ? Array.from(new Set(numericValues)).sort((a, b) => a - b)
+        : [];
+      const secondMinValue =
+        sortedUniqueValues.length >= 3 ? sortedUniqueValues[1] : null;
+      const secondMaxValue =
+        sortedUniqueValues.length >= 3
+          ? sortedUniqueValues[sortedUniqueValues.length - 2]
+          : null;
+
+      const cells = state.comparisonData
+        .map((city) => {
+          const value = toNumber(city.numbeo_indices?.[row.key]);
+          let cellClass = "indices-value";
+
+          if (
+            value != null &&
+            minValue != null &&
+            maxValue != null &&
+            minValue !== maxValue
+          ) {
+            if (isHigherBetter) {
+              if (value === minValue) {
+                cellClass += " cost-value-high";
+              } else if (value === maxValue) {
+                cellClass += " cost-value-low";
+              } else if (
+                shouldApplySecondary &&
+                secondMinValue != null &&
+                value === secondMinValue
+              ) {
+                cellClass += " cost-value-high-soft";
+              } else if (
+                shouldApplySecondary &&
+                secondMaxValue != null &&
+                value === secondMaxValue
+              ) {
+                cellClass += " cost-value-low-soft";
+              }
+            } else if (value === minValue) {
+              cellClass += " cost-value-low";
+            } else if (value === maxValue) {
+              cellClass += " cost-value-high";
+            } else if (
+              shouldApplySecondary &&
+              secondMinValue != null &&
+              value === secondMinValue
+            ) {
+              cellClass += " cost-value-low-soft";
+            } else if (
+              shouldApplySecondary &&
+              secondMaxValue != null &&
+              value === secondMaxValue
+            ) {
+              cellClass += " cost-value-high-soft";
+            }
+          }
+
+          return `<td class="${cellClass}">${escapeHtml(formatIndexValue(value))}</td>`;
+        })
+        .join("");
+
+      return `
+        <tr>
+          <td class="indices-item-name">
+            <button
+              class="cost-item-sort ${isActiveSort ? "is-active" : ""}"
+              type="button"
+              data-index-key="${escapeHtml(row.key)}"
+              data-index-sort-direction="${sortDirection ?? ""}"
+            >
+              <span>${escapeHtml(row.label)}</span>
+              <span class="cost-item-sort-indicator" aria-hidden="true">${sortDirection === "asc" ? "↑" : sortDirection === "desc" ? "↓" : ""}</span>
+            </button>
+          </td>
+          ${cells}
+        </tr>
+      `;
+    })
+    .join("");
+
+  els.numbeoIndicesBody
+    .querySelectorAll("[data-index-key]")
+    .forEach((button) => {
+      button.addEventListener("click", () => {
+        const key = button.dataset.indexKey;
+        if (!key) return;
+        applyIndicesSort(key);
+      });
+    });
+}
+
 function buildCostBreakdownDataset(cities) {
   if (!cities.length) return [];
 
@@ -841,6 +996,7 @@ function resetDashboard() {
   state.costBreakdownData = [];
   state.collapsedCostCategories.clear();
   state.breakdownSort = null;
+  state.indicesSort = null;
   state.climateHiddenCities.clear();
   state.climateHoveredCityKey = null;
 
@@ -852,6 +1008,7 @@ function resetDashboard() {
   renderSelectedCountries();
   renderSelectedCities();
   renderCostBreakdownTable();
+  renderNumbeoIndicesTable();
 
   els.chartEmptyState.classList.remove("hidden");
   els.climateChartsGrid.classList.add("hidden");
@@ -1214,6 +1371,11 @@ function formatTooltipValue(value, unit) {
   return `${raw} ${unit}`;
 }
 
+function formatIndexValue(value) {
+  if (value == null) return "—";
+  return String(value);
+}
+
 function getBaseDatasetColor(dataset) {
   return dataset._baseColor ?? "#2563eb";
 }
@@ -1273,9 +1435,28 @@ function applyBreakdownSort(param) {
 
   sortComparisonDataByCostParam(param, nextDirection);
   state.breakdownSort = { param, direction: nextDirection };
+  state.indicesSort = null;
   state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
 
   renderCostBreakdownTable();
+  renderNumbeoIndicesTable();
+}
+
+function applyIndicesSort(key) {
+  if (!state.comparisonData.length) return;
+
+  const nextDirection =
+    state.indicesSort?.key === key && state.indicesSort.direction === "desc"
+      ? "asc"
+      : "desc";
+
+  sortComparisonDataByIndexKey(key, nextDirection);
+  state.indicesSort = { key, direction: nextDirection };
+  state.breakdownSort = null;
+  state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
+
+  renderCostBreakdownTable();
+  renderNumbeoIndicesTable();
 }
 
 function applyLoadedComparisonSelection() {
@@ -1289,13 +1470,16 @@ function applyLoadedComparisonSelection() {
   if (state.comparisonData.length === 0) {
     state.costBreakdownData = [];
     state.breakdownSort = null;
+    state.indicesSort = null;
     renderCostBreakdownTable();
+    renderNumbeoIndicesTable();
     renderClimateChart();
     return;
   }
 
   state.costBreakdownData = buildCostBreakdownDataset(state.comparisonData);
   renderCostBreakdownTable();
+  renderNumbeoIndicesTable();
   renderClimateChart();
 }
 
@@ -1307,6 +1491,29 @@ function sortComparisonDataByCostParam(param, direction) {
       city,
       index,
       value: getCostParamValue(city, param),
+    }))
+    .sort((a, b) => {
+      const aMissing = a.value == null;
+      const bMissing = b.value == null;
+
+      if (aMissing && bMissing) return a.index - b.index;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+      if (a.value === b.value) return a.index - b.index;
+
+      return (a.value - b.value) * multiplier;
+    })
+    .map((entry) => entry.city);
+}
+
+function sortComparisonDataByIndexKey(key, direction) {
+  const multiplier = direction === "asc" ? 1 : -1;
+
+  state.comparisonData = state.comparisonData
+    .map((city, index) => ({
+      city,
+      index,
+      value: toNumber(city.numbeo_indices?.[key]),
     }))
     .sort((a, b) => {
       const aMissing = a.value == null;

--- a/ui/app.js
+++ b/ui/app.js
@@ -1,0 +1,500 @@
+const state = {
+  countries: [],
+  cities: [],
+  selectedCountryCodes: new Set(),
+  selectedCityIds: new Set(),
+  comparisonData: [],
+  climateChart: null,
+};
+
+const els = {
+  countrySearch: document.getElementById("countrySearch"),
+  citySearch: document.getElementById("citySearch"),
+  countryList: document.getElementById("countryList"),
+  cityList: document.getElementById("cityList"),
+  selectedCountries: document.getElementById("selectedCountries"),
+  selectedCities: document.getElementById("selectedCities"),
+  compareBtn: document.getElementById("compareBtn"),
+  resetBtn: document.getElementById("resetBtn"),
+  tableEmptyState: document.getElementById("tableEmptyState"),
+  chartEmptyState: document.getElementById("chartEmptyState"),
+  comparisonTableWrapper: document.getElementById("comparisonTableWrapper"),
+  comparisonTableBody: document.querySelector("#comparisonTable tbody"),
+  metricCities: document.getElementById("metricCities"),
+  metricCountries: document.getElementById("metricCountries"),
+  metricLowestRent: document.getElementById("metricLowestRent"),
+  metricBestQol: document.getElementById("metricBestQol"),
+  climateCanvas: document.getElementById("climateChart"),
+};
+
+document.addEventListener("DOMContentLoaded", () => {
+  bindEvents();
+  loadCountries();
+});
+
+function bindEvents() {
+  els.countrySearch.addEventListener("input", renderCountries);
+  els.citySearch.addEventListener("input", renderCities);
+  els.compareBtn.addEventListener("click", loadComparison);
+  els.resetBtn.addEventListener("click", resetDashboard);
+}
+
+async function loadCountries() {
+  try {
+    const res = await fetch("/countries");
+    if (!res.ok) throw new Error(`Failed to load countries: ${res.status}`);
+
+    const data = await res.json();
+
+    // Expected flexible parsing
+    state.countries = Array.isArray(data.countries)
+      ? data.countries
+      : Array.isArray(data.data)
+        ? data.data
+        : [];
+
+    renderCountries();
+    renderSelectedCountries();
+    updateMetrics();
+  } catch (error) {
+    console.error(error);
+    els.countryList.innerHTML = `<div class="empty-state">Failed to load countries.</div>`;
+  }
+}
+
+async function loadCitiesForSelectedCountries() {
+  const selectedCodes = Array.from(state.selectedCountryCodes);
+  state.cities = [];
+  state.selectedCityIds.clear();
+
+  if (selectedCodes.length === 0) {
+    renderCities();
+    renderSelectedCities();
+    updateMetrics();
+    return;
+  }
+
+  try {
+    const results = await Promise.all(
+      selectedCodes.map((code) =>
+        fetch(`/cities?country_code=${encodeURIComponent(code)}`).then(
+          (res) => {
+            if (res.status === 404) return { cities: [] };
+            if (!res.ok) throw new Error(`Failed to load cities for ${code}`);
+            return res.json();
+          },
+        ),
+      ),
+    );
+
+    const allCities = results.flatMap((data) => {
+      if (Array.isArray(data.cities)) return data.cities;
+      if (Array.isArray(data.data)) return data.data;
+      return [];
+    });
+
+    const uniqueMap = new Map();
+    for (const city of allCities) {
+      const id = city.geoname_id ?? city.city_id ?? city.id;
+      if (id != null) uniqueMap.set(String(id), city);
+    }
+
+    state.cities = Array.from(uniqueMap.values()).sort((a, b) => {
+      const aName = (a.city ?? a.name ?? "").toLowerCase();
+      const bName = (b.city ?? b.name ?? "").toLowerCase();
+      return aName.localeCompare(bName);
+    });
+
+    renderCities();
+    renderSelectedCities();
+    updateMetrics();
+  } catch (error) {
+    console.error(error);
+    els.cityList.innerHTML = `<div class="empty-state">Failed to load cities.</div>`;
+  }
+}
+
+function renderCountries() {
+  const q = els.countrySearch.value.trim().toLowerCase();
+
+  const filtered = state.countries.filter((country) => {
+    const code = (country.country_code ?? country.code ?? "").toLowerCase();
+    const name = (
+      country.country ??
+      country.country_name ??
+      country.name ??
+      ""
+    ).toLowerCase();
+    return name.includes(q) || code.includes(q);
+  });
+
+  if (filtered.length === 0) {
+    els.countryList.innerHTML = `<div class="empty-state">No countries found.</div>`;
+    return;
+  }
+
+  els.countryList.innerHTML = filtered
+    .map((country) => {
+      const code = country.country_code ?? country.code ?? "";
+      const name =
+        country.country ?? country.country_name ?? country.name ?? code;
+      const checked = state.selectedCountryCodes.has(code) ? "checked" : "";
+
+      return `
+        <label class="selection-item">
+          <input type="checkbox" data-country-code="${escapeHtml(code)}" ${checked} />
+          <div class="selection-item-main">
+            <span class="selection-title">${escapeHtml(name)}</span>
+            <span class="selection-subtitle">${escapeHtml(code)}</span>
+          </div>
+        </label>
+      `;
+    })
+    .join("");
+
+  els.countryList
+    .querySelectorAll("input[data-country-code]")
+    .forEach((input) => {
+      input.addEventListener("change", async (e) => {
+        const code = e.target.dataset.countryCode;
+        if (!code) return;
+
+        if (e.target.checked) {
+          state.selectedCountryCodes.add(code);
+        } else {
+          state.selectedCountryCodes.delete(code);
+        }
+
+        renderSelectedCountries();
+        updateMetrics();
+        await loadCitiesForSelectedCountries();
+      });
+    });
+}
+
+function renderCities() {
+  const q = els.citySearch.value.trim().toLowerCase();
+
+  const filtered = state.cities.filter((city) => {
+    const cityName = (city.city ?? city.name ?? "").toLowerCase();
+    const countryName = (city.country ?? city.country_name ?? "").toLowerCase();
+    return cityName.includes(q) || countryName.includes(q);
+  });
+
+  if (filtered.length === 0) {
+    els.cityList.innerHTML = `<div class="empty-state">Select countries to load cities.</div>`;
+    return;
+  }
+
+  els.cityList.innerHTML = filtered
+    .map((city) => {
+      const id = String(city.geoname_id ?? city.city_id ?? city.id ?? "");
+      const cityName = city.city ?? city.name ?? id;
+      const countryName =
+        city.country ?? city.country_name ?? city.country_code ?? "";
+      const checked = state.selectedCityIds.has(id) ? "checked" : "";
+
+      return `
+        <label class="selection-item">
+          <input type="checkbox" data-city-id="${escapeHtml(id)}" ${checked} />
+          <div class="selection-item-main">
+            <span class="selection-title">${escapeHtml(cityName)}</span>
+            <span class="selection-subtitle">${escapeHtml(countryName)}</span>
+          </div>
+        </label>
+      `;
+    })
+    .join("");
+
+  els.cityList.querySelectorAll("input[data-city-id]").forEach((input) => {
+    input.addEventListener("change", (e) => {
+      const id = e.target.dataset.cityId;
+      if (!id) return;
+
+      if (e.target.checked) {
+        state.selectedCityIds.add(id);
+      } else {
+        state.selectedCityIds.delete(id);
+      }
+
+      renderSelectedCities();
+      updateMetrics();
+    });
+  });
+}
+
+function renderSelectedCountries() {
+  const items = state.countries.filter((c) =>
+    state.selectedCountryCodes.has(c.country_code ?? c.code ?? ""),
+  );
+
+  if (items.length === 0) {
+    els.selectedCountries.innerHTML = `<span class="chip">None</span>`;
+    return;
+  }
+
+  els.selectedCountries.innerHTML = items
+    .map((country) => {
+      const name =
+        country.country ?? country.country_name ?? country.name ?? "";
+      return `<span class="chip">${escapeHtml(name)}</span>`;
+    })
+    .join("");
+}
+
+function renderSelectedCities() {
+  const items = state.cities.filter((c) =>
+    state.selectedCityIds.has(String(c.geoname_id ?? c.city_id ?? c.id ?? "")),
+  );
+
+  if (items.length === 0) {
+    els.selectedCities.innerHTML = `<span class="chip">None</span>`;
+    return;
+  }
+
+  els.selectedCities.innerHTML = items
+    .map((city) => {
+      const name = city.city ?? city.name ?? "";
+      return `<span class="chip">${escapeHtml(name)}</span>`;
+    })
+    .join("");
+}
+
+async function loadComparison() {
+  const cityIds = Array.from(state.selectedCityIds);
+  if (cityIds.length === 0) {
+    alert("Select at least one city.");
+    return;
+  }
+
+  const include = "numbeo_cost,numbeo_indices,avg_climate";
+  const qs = new URLSearchParams();
+  qs.set("ids", cityIds.join(","));
+  qs.set("include", include);
+
+  try {
+    const res = await fetch(`/cities?${qs.toString()}`);
+    if (!res.ok) throw new Error(`Failed to load comparison: ${res.status}`);
+
+    const data = await res.json();
+    state.comparisonData = Array.isArray(data.cities)
+      ? data.cities
+      : Array.isArray(data.data)
+        ? data.data
+        : [];
+
+    renderComparisonTable();
+    renderClimateChart();
+    updateMetrics();
+  } catch (error) {
+    console.error(error);
+    alert("Failed to load comparison data.");
+  }
+}
+
+function renderComparisonTable() {
+  if (!state.comparisonData.length) {
+    els.tableEmptyState.classList.remove("hidden");
+    els.comparisonTableWrapper.classList.add("hidden");
+    return;
+  }
+
+  els.tableEmptyState.classList.add("hidden");
+  els.comparisonTableWrapper.classList.remove("hidden");
+
+  els.comparisonTableBody.innerHTML = state.comparisonData
+    .map((city) => {
+      const cityName = city.city ?? city.name ?? "—";
+      const country =
+        city.country ?? city.country_name ?? city.country_code ?? "—";
+      const idx = city.numbeo_indices ?? {};
+      return `
+        <tr>
+          <td>${escapeHtml(String(cityName))}</td>
+          <td>${escapeHtml(String(country))}</td>
+          <td>${fmt(idx.cost_of_living)}</td>
+          <td>${fmt(idx.rent_index ?? idx.rent)}</td>
+          <td>${fmt(idx.groceries_index ?? idx.groceries)}</td>
+          <td>${fmt(idx.restaurant_price_index ?? idx.restaurant)}</td>
+          <td>${fmt(idx.quality_of_life)}</td>
+          <td>${fmt(idx.safety)}</td>
+          <td>${fmt(idx.health_care)}</td>
+        </tr>
+      `;
+    })
+    .join("");
+}
+
+function renderClimateChart() {
+  const datasets = [];
+  const labels = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+
+  for (const city of state.comparisonData) {
+    const climate = city.avg_climate ?? {};
+    const highTemp =
+      climate.high_temp ?? climate.high_temps ?? climate.avg_high_temp ?? [];
+
+    if (Array.isArray(highTemp) && highTemp.length > 0) {
+      datasets.push({
+        label: city.city ?? city.name ?? "City",
+        data: normalizeMonthlySeries(highTemp),
+        tension: 0.3,
+      });
+    }
+  }
+
+  if (datasets.length === 0) {
+    els.chartEmptyState.classList.remove("hidden");
+    if (state.climateChart) {
+      state.climateChart.destroy();
+      state.climateChart = null;
+    }
+    return;
+  }
+
+  els.chartEmptyState.classList.add("hidden");
+
+  if (state.climateChart) {
+    state.climateChart.destroy();
+  }
+
+  state.climateChart = new Chart(els.climateCanvas, {
+    type: "line",
+    data: {
+      labels,
+      datasets,
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        mode: "nearest",
+        intersect: false,
+      },
+      plugins: {
+        legend: {
+          position: "top",
+        },
+      },
+      scales: {
+        y: {
+          title: {
+            display: true,
+            text: "Temperature",
+          },
+        },
+      },
+    },
+  });
+}
+
+function updateMetrics() {
+  els.metricCities.textContent = String(state.selectedCityIds.size);
+  els.metricCountries.textContent = String(state.selectedCountryCodes.size);
+
+  if (!state.comparisonData.length) {
+    els.metricLowestRent.textContent = "—";
+    els.metricBestQol.textContent = "—";
+    return;
+  }
+
+  let lowestRentCity = null;
+  let bestQolCity = null;
+
+  for (const city of state.comparisonData) {
+    const idx = city.numbeo_indices ?? {};
+    const rent = toNumber(idx.rent_index ?? idx.rent);
+    const qol = toNumber(idx.quality_of_life);
+
+    if (rent != null) {
+      if (!lowestRentCity || rent < lowestRentCity.value) {
+        lowestRentCity = {
+          name: city.city ?? city.name ?? "—",
+          value: rent,
+        };
+      }
+    }
+
+    if (qol != null) {
+      if (!bestQolCity || qol > bestQolCity.value) {
+        bestQolCity = {
+          name: city.city ?? city.name ?? "—",
+          value: qol,
+        };
+      }
+    }
+  }
+
+  els.metricLowestRent.textContent = lowestRentCity
+    ? `${lowestRentCity.name} (${fmt(lowestRentCity.value)})`
+    : "—";
+
+  els.metricBestQol.textContent = bestQolCity
+    ? `${bestQolCity.name} (${fmt(bestQolCity.value)})`
+    : "—";
+}
+
+function resetDashboard() {
+  state.selectedCountryCodes.clear();
+  state.selectedCityIds.clear();
+  state.cities = [];
+  state.comparisonData = [];
+
+  els.countrySearch.value = "";
+  els.citySearch.value = "";
+
+  renderCountries();
+  renderCities();
+  renderSelectedCountries();
+  renderSelectedCities();
+  renderComparisonTable();
+
+  els.chartEmptyState.classList.remove("hidden");
+  if (state.climateChart) {
+    state.climateChart.destroy();
+    state.climateChart = null;
+  }
+
+  updateMetrics();
+}
+
+function normalizeMonthlySeries(arr) {
+  const out = new Array(12).fill(null);
+  for (let i = 0; i < Math.min(arr.length, 12); i += 1) {
+    out[i] = toNumber(arr[i]);
+  }
+  return out;
+}
+
+function toNumber(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function fmt(value) {
+  const n = toNumber(value);
+  return n == null ? "—" : n.toFixed(1);
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}

--- a/ui/climate.js
+++ b/ui/climate.js
@@ -1,0 +1,421 @@
+function renderClimateChart() {
+  const chartCities = [...state.comparisonData].sort((a, b) => {
+    const aName = (a.city ?? a.name ?? "").toLowerCase();
+    const bName = (b.city ?? b.name ?? "").toLowerCase();
+    return aName.localeCompare(bName);
+  });
+  const labels = [
+    "Jan",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+  const climateCities = chartCities.map((city, index) =>
+    buildClimateCityConfig(city, index),
+  );
+
+  if (climateCities.length === 0) {
+    els.chartEmptyState.classList.remove("hidden");
+    els.climateChartsGrid.classList.add("hidden");
+    destroyClimateCharts();
+    return;
+  }
+
+  els.chartEmptyState.classList.add("hidden");
+  els.climateChartsGrid.classList.remove("hidden");
+
+  destroyClimateCharts();
+
+  state.climateCharts = [
+    new Chart(
+      els.climateTemperatureCanvas,
+      buildClimateChartConfig({
+        chartKey: "temperature",
+        labels,
+        datasets: climateCities.flatMap((city) => [
+          buildClimateDataset(city, "high_temp", {
+            datasetLabel: `${city.name} high`,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+            borderDash: [],
+            variant: "high",
+          }),
+          buildClimateDataset(city, "low_temp", {
+            datasetLabel: `${city.name} low`,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+            borderDash: [8, 5],
+            variant: "low",
+          }),
+        ]),
+        yTitle: "°C",
+        showLegend: true,
+      }),
+    ),
+    new Chart(
+      els.climateSunshineCanvas,
+      buildClimateChartConfig({
+        chartKey: "sunshine",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "sunshine", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "Hours",
+      }),
+    ),
+    new Chart(
+      els.climateDaylightCanvas,
+      buildClimateChartConfig({
+        chartKey: "daylight",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "daylight", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "Hours",
+      }),
+    ),
+    new Chart(
+      els.climateHumidityCanvas,
+      buildClimateChartConfig({
+        chartKey: "humidity",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "humidity", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "%",
+      }),
+    ),
+    new Chart(
+      els.climateRainfallCanvas,
+      buildClimateChartConfig({
+        chartKey: "rainfall",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "rainfall", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "mm",
+      }),
+    ),
+    new Chart(
+      els.climateWindCanvas,
+      buildClimateChartConfig({
+        chartKey: "wind",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "wind_speed", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "km/h",
+      }),
+    ),
+    new Chart(
+      els.climateUVIndexCanvas,
+      buildClimateChartConfig({
+        chartKey: "uv_index",
+        labels,
+        datasets: climateCities.map((city) =>
+          buildClimateDataset(city, "uv_index", {
+            datasetLabel: city.name,
+            cityLabel: city.name,
+            cityKey: city.key,
+            color: city.color,
+          }),
+        ),
+        yTitle: "",
+        reserveYAxisTitleSpace: true,
+      }),
+    ),
+  ];
+
+  syncClimateChartStyles();
+}
+
+function normalizeMonthlySeries(arr) {
+  const out = new Array(12).fill(null);
+  for (let i = 0; i < Math.min(arr.length, 12); i += 1) {
+    out[i] = toNumber(arr[i]);
+  }
+  return out;
+}
+
+function buildClimateCityConfig(city, index) {
+  const climate = city.avg_climate ?? buildPlaceholderClimate(city, index);
+  const key = String(city.geoname_id ?? city.city_id ?? city.id ?? city.city ?? index);
+  return {
+    key,
+    name: city.city ?? city.name ?? `City ${index + 1}`,
+    climate,
+    color: getClimateColor(index),
+  };
+}
+
+function buildPlaceholderClimate(city, index) {
+  const offset = index * 1.4;
+  return {
+    high_temp: [5, 7, 11, 16, 21, 25, 28, 28, 23, 17, 11, 7].map((v) => v + offset),
+    low_temp: [-1, 0, 3, 8, 13, 17, 20, 20, 16, 10, 5, 1].map((v) => v + offset),
+    sunshine: [3, 4, 5, 7, 8, 9, 10, 9, 7, 5, 4, 3].map((v) => Math.max(0, v - index * 0.2)),
+    daylight: [9, 10, 12, 13, 15, 16, 15, 14, 12, 11, 9, 8].map((v) => v),
+    humidity: [76, 74, 71, 69, 68, 66, 64, 65, 68, 72, 75, 77].map((v) => v + index),
+    rainfall: [62, 58, 61, 67, 72, 76, 81, 79, 70, 66, 64, 68].map((v) => v + index * 4),
+    wind_speed: [14, 13, 13, 12, 11, 10, 9, 9, 10, 11, 12, 13].map((v) => Math.max(3, v - index * 0.3)),
+    uv_index: [1, 2, 3, 5, 6, 7, 8, 7, 5, 3, 2, 1].map((v) => Math.min(11, Math.max(0, v + index * 0.2))),
+  };
+}
+
+function getClimateColor(index) {
+  const palette = [
+    "#2563eb",
+    "#ef4444",
+    "#0f766e",
+    "#d97706",
+    "#7c3aed",
+    "#db2777",
+    "#0891b2",
+    "#65a30d",
+    "#c2410c",
+    "#475569",
+    "#16a34a",
+    "#ea580c",
+    "#4f46e5",
+    "#be123c",
+    "#0d9488",
+  ];
+  return palette[index % palette.length];
+}
+
+function buildClimateDataset(city, metricKey, options = {}) {
+  const rawSeries = city.climate?.[metricKey] ?? [];
+  const baseColor = options.color ?? city.color;
+  return {
+    label: options.datasetLabel ?? city.name,
+    data: normalizeMonthlySeries(rawSeries),
+    borderColor: baseColor,
+    backgroundColor: withAlpha(baseColor, 0.12),
+    borderWidth: 2.5,
+    tension: 0.35,
+    pointRadius: 0,
+    pointHoverRadius: 4,
+    pointHitRadius: 14,
+    fill: false,
+    borderDash: options.borderDash ?? [],
+    cityKey: options.cityKey ?? city.key,
+    cityLabel: options.cityLabel ?? city.name,
+    variant: options.variant ?? "default",
+    _baseColor: baseColor,
+  };
+}
+
+function buildClimateChartConfig({
+  chartKey,
+  labels,
+  datasets,
+  yTitle,
+  reserveYAxisTitleSpace = false,
+  showLegend = false,
+}) {
+  return {
+    type: "line",
+    data: { labels, datasets },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        mode: "nearest",
+        intersect: false,
+      },
+      onHover: (_event, elements, chart) => {
+        const hoveredDataset = elements.length > 0
+          ? chart.data.datasets[elements[0].datasetIndex]
+          : null;
+        setHoveredClimateCity(hoveredDataset?.cityKey ?? null);
+      },
+      plugins: {
+        legend: showLegend
+          ? {
+              position: "top",
+              labels: {
+                usePointStyle: true,
+                pointStyle: "circle",
+                boxWidth: 10,
+                boxHeight: 10,
+                padding: 14,
+                font: {
+                  size: 13,
+                  lineHeight: 1.15,
+                },
+                generateLabels: (chart) => {
+                  const seen = new Set();
+                  const labels = [];
+                  chart.data.datasets.forEach((dataset, datasetIndex) => {
+                    if (seen.has(dataset.cityKey)) return;
+                    seen.add(dataset.cityKey);
+                    const isHidden = state.climateHiddenCities.has(dataset.cityKey);
+                    labels.push({
+                      text: dataset.cityLabel,
+                      fillStyle: withAlpha(dataset._baseColor, isHidden ? 0.18 : 0.9),
+                      strokeStyle: withAlpha(dataset._baseColor, isHidden ? 0.18 : 0.9),
+                      lineWidth: 2,
+                      hidden: isHidden,
+                      datasetIndex,
+                      cityKey: dataset.cityKey,
+                    });
+                  });
+                  return labels;
+                },
+              },
+              onClick: (_event, legendItem) => {
+                const cityKey = legendItem.cityKey;
+                if (!cityKey) return;
+                if (state.climateHiddenCities.has(cityKey)) {
+                  state.climateHiddenCities.delete(cityKey);
+                } else {
+                  state.climateHiddenCities.add(cityKey);
+                }
+                syncClimateChartStyles();
+              },
+            }
+          : {
+              display: false,
+            },
+        tooltip: {
+          enabled: false,
+          mode: "nearest",
+          intersect: false,
+          external: (context) =>
+            renderClimateTooltip(context, { chartKey, yTitle }),
+        },
+      },
+      scales: {
+        x: {
+          grid: {
+            color: "rgba(148, 163, 184, 0.12)",
+          },
+          ticks: {
+            color: "#64748b",
+          },
+        },
+        y: {
+          grid: {
+            color: "rgba(148, 163, 184, 0.12)",
+          },
+          ticks: {
+            color: "#64748b",
+          },
+          title: {
+            display: Boolean(yTitle) || reserveYAxisTitleSpace,
+            text: yTitle || " ",
+            color: yTitle ? "#64748b" : "rgba(0,0,0,0)",
+            font: {
+              size: 12,
+              weight: "600",
+            },
+          },
+        },
+      },
+      elements: {
+        line: {
+          capBezierPoints: true,
+        },
+      },
+    },
+    plugins: [
+      {
+        id: `climate-hover-reset-${chartKey}`,
+        afterEvent: (_chart, args) => {
+          if (args.event.type === "mouseout") {
+            setHoveredClimateCity(null);
+          }
+        },
+      },
+    ],
+  };
+}
+
+function destroyClimateCharts() {
+  state.climateCharts.forEach((chart) => chart.destroy());
+  state.climateCharts = [];
+}
+
+function setHoveredClimateCity(cityKey) {
+  if (state.climateHoveredCityKey === cityKey) return;
+  state.climateHoveredCityKey = cityKey;
+  syncClimateChartStyles();
+}
+
+function syncClimateChartStyles() {
+  state.climateCharts.forEach((chart) => {
+    chart.data.datasets.forEach((dataset) => {
+      const isHidden = state.climateHiddenCities.has(dataset.cityKey);
+      const isHovered =
+        state.climateHoveredCityKey &&
+        state.climateHoveredCityKey === dataset.cityKey;
+      const shouldFade =
+        state.climateHoveredCityKey && !isHovered;
+      const baseColor = getBaseDatasetColor(dataset);
+      const isLowVariant = dataset.variant === "low";
+      const alpha = isHidden
+        ? 0.06
+        : shouldFade
+          ? isLowVariant ? 0.18 : 0.3
+          : isHovered
+            ? isLowVariant ? 0.86 : 1
+            : isLowVariant ? 0.5 : 0.76;
+
+      dataset.hidden = isHidden;
+      dataset.borderColor = withAlpha(baseColor, alpha);
+      dataset.backgroundColor = withAlpha(
+        baseColor,
+        isHidden ? 0.03 : shouldFade ? 0.05 : isLowVariant ? 0.08 : 0.15,
+      );
+      dataset.borderWidth = isHovered
+        ? isLowVariant ? 2.3 : 3.3
+        : isLowVariant ? 1.7 : 2.2;
+      dataset.pointRadius = isHovered ? 2.5 : 0;
+    });
+    chart.update("none");
+  });
+}
+
+function getBaseDatasetColor(dataset) {
+  return dataset._baseColor ?? "#2563eb";
+}
+
+Object.assign(window, {
+  renderClimateChart,
+  destroyClimateCharts,
+});

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 )
 
-//go:embed index.html app.js styles.css
+//go:embed index.html app.js styles.css favicon.svg
 var embeddedFiles embed.FS
 
 func ReadFile(name string) ([]byte, error) {

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -5,7 +5,7 @@ import (
 	"io/fs"
 )
 
-//go:embed index.html app.js styles.css favicon.svg
+//go:embed index.html app.js helpers.js tooltips.js climate.js styles.css favicon.svg
 var embeddedFiles embed.FS
 
 func ReadFile(name string) ([]byte, error) {

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -1,0 +1,13 @@
+package uiassets
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed index.html app.js styles.css
+var embeddedFiles embed.FS
+
+func ReadFile(name string) ([]byte, error) {
+	return fs.ReadFile(embeddedFiles, name)
+}

--- a/ui/favicon.svg
+++ b/ui/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#0f172a"></rect>
+  
+  <!-- horizontal bars -->
+  <rect x="12" y="14" width="38" height="8" rx="2" fill="#3b82f6"></rect>
+  <rect x="12" y="28" width="28" height="8" rx="2" fill="#60a5fa"></rect>
+  <rect x="12" y="42" width="46" height="8" rx="2" fill="#93c5fd"></rect>
+</svg>

--- a/ui/helpers.js
+++ b/ui/helpers.js
@@ -1,0 +1,188 @@
+const countryDisplayNames = {
+  "Bolivia, Plurinational State of": "Bolivia",
+  "Bosnia and Herzegovina": "Bosnia & Herzegovina",
+  "Dominican Republic": "Dominican Rep.",
+  "Iran, Islamic Republic of": "Iran",
+  "Korea, Republic of": "South Korea",
+  "Moldova, Republic of": "Moldova",
+  "Netherlands, Kingdom of the": "Netherlands",
+  "North Macedonia": "N. Macedonia",
+  "Russian Federation": "Russia",
+  "Syrian Arab Republic": "Syria",
+  "Taiwan, Province of China": "Taiwan",
+  "Tanzania, United Republic of": "Tanzania",
+  "United Arab Emirates": "UAE",
+  "United Kingdom of Great Britain and Northern Ireland": "United Kingdom",
+  "United States of America": "USA",
+  "Venezuela, Bolivarian Republic of": "Venezuela",
+};
+
+function getDisplayCountryName(country) {
+  const raw = String(country ?? "");
+  return countryDisplayNames[raw] ?? raw;
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function toNumber(value) {
+  if (value == null) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function withAlpha(color, alpha) {
+  const hex = color.replace("#", "");
+  const normalized =
+    hex.length === 3
+      ? hex
+          .split("")
+          .map((char) => char + char)
+          .join("")
+      : hex;
+  const r = parseInt(normalized.slice(0, 2), 16);
+  const g = parseInt(normalized.slice(2, 4), 16);
+  const b = parseInt(normalized.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+function formatCompactPopulation(value) {
+  const n = toNumber(value);
+  if (n == null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n);
+}
+
+function formatCompactArea(value) {
+  const n = toNumber(value);
+  if (n == null) return "—";
+  return `${new Intl.NumberFormat("en-US", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(n)} km²`;
+}
+
+function formatUTCOffset(timezone) {
+  if (!timezone) return "—";
+
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      timeZoneName: "shortOffset",
+    }).formatToParts(new Date());
+    const timeZoneName =
+      parts.find((part) => part.type === "timeZoneName")?.value ?? "";
+
+    if (!timeZoneName) return String(timezone);
+    return timeZoneName.replace("GMT", "UTC");
+  } catch {
+    return String(timezone);
+  }
+}
+
+function formatTooltipValue(value, unit) {
+  if (value == null) return "—";
+  const raw = String(value);
+  if (unit === "%" || unit === "mm") {
+    return `${raw}${unit}`;
+  }
+  if (unit === "km/h") {
+    return `${raw} km/h`;
+  }
+  if (unit === "UV") {
+    return raw;
+  }
+  if (unit === "Hours") {
+    return `${raw} h`;
+  }
+  if (unit === "°C") {
+    return `${raw}${unit}`;
+  }
+  return `${raw} ${unit}`;
+}
+
+function formatTooltipValueParts(value, unit) {
+  if (value == null) {
+    return { value: "—", unit: "" };
+  }
+
+  const raw = String(value);
+  if (unit === "%" || unit === "mm" || unit === "°C") {
+    return { value: raw, unit };
+  }
+  if (unit === "" || unit === "UV") {
+    return { value: raw, unit: "" };
+  }
+  if (unit === "km/h") {
+    return { value: raw, unit: "km/h" };
+  }
+  if (unit === "Hours") {
+    return { value: raw, unit: "h" };
+  }
+  return { value: raw, unit };
+}
+
+function formatIndexValue(value, row = null) {
+  if (value == null) return "—";
+  if (row?.format === "currency") {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: value >= 100 ? 0 : 2,
+      minimumFractionDigits: value >= 100 ? 0 : 2,
+    }).format(value);
+  }
+  return String(value);
+}
+
+function fmt(value) {
+  const n = toNumber(value);
+  return n == null ? "—" : n.toFixed(1);
+}
+
+function formatCostValue(value, options = {}) {
+  if (!value) return "—";
+  const n = toNumber(value.cost);
+  if (n == null) return "—";
+
+  if (options.isMortgageRate) {
+    return `${n.toFixed(2)}%`;
+  }
+
+  const fractionDigits = n >= 100 ? 0 : 2;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: value.currency ?? "USD",
+    maximumFractionDigits: fractionDigits,
+    minimumFractionDigits: fractionDigits,
+  }).format(n);
+}
+
+function formatLegatumAxisMidValue(value) {
+  if (!Number.isFinite(value)) return "—";
+  return String(Math.round(value));
+}
+
+Object.assign(window, {
+  getDisplayCountryName,
+  escapeHtml,
+  toNumber,
+  withAlpha,
+  formatCompactPopulation,
+  formatCompactArea,
+  formatUTCOffset,
+  formatTooltipValue,
+  formatTooltipValueParts,
+  formatIndexValue,
+  fmt,
+  formatCostValue,
+  formatLegatumAxisMidValue,
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Relohelper Dashboard</title>
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="stylesheet" href="./styles.css" />
         <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
         <script defer src="./app.js"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,6 +7,9 @@
         <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
         <link rel="stylesheet" href="./styles.css" />
         <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        <script defer src="./helpers.js"></script>
+        <script defer src="./tooltips.js"></script>
+        <script defer src="./climate.js"></script>
         <script defer src="./app.js"></script>
     </head>
     <body>

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Relohelper Dashboard</title>
+        <link rel="stylesheet" href="./styles.css" />
+        <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+        <script defer src="./app.js"></script>
+    </head>
+    <body>
+        <div class="app-shell">
+            <header class="topbar">
+                <div>
+                    <p class="eyebrow">Relohelper</p>
+                    <h1>City Comparison Dashboard</h1>
+                    <p class="subtitle">
+                        Compare multiple cities by cost of living, indices, and
+                        climate.
+                    </p>
+                </div>
+
+                <div class="topbar-actions">
+                    <button id="compareBtn" class="btn btn-primary">
+                        Compare
+                    </button>
+                    <button id="resetBtn" class="btn btn-secondary">
+                        Reset
+                    </button>
+                </div>
+            </header>
+
+            <main class="dashboard-grid">
+                <section class="card filters-card">
+                    <div class="card-header">
+                        <h2>Filters</h2>
+                        <p>Select countries first, then cities.</p>
+                    </div>
+
+                    <div class="filters-grid">
+                        <div class="filter-block">
+                            <label for="countrySearch">Search countries</label>
+                            <input
+                                id="countrySearch"
+                                class="text-input"
+                                type="text"
+                                placeholder="Type country name..."
+                            />
+                            <div id="countryList" class="selection-list"></div>
+                        </div>
+
+                        <div class="filter-block">
+                            <label for="citySearch">Search cities</label>
+                            <input
+                                id="citySearch"
+                                class="text-input"
+                                type="text"
+                                placeholder="Type city name..."
+                            />
+                            <div id="cityList" class="selection-list"></div>
+                        </div>
+                    </div>
+
+                    <div class="selected-summary">
+                        <div>
+                            <span class="summary-label"
+                                >Selected countries</span
+                            >
+                            <div id="selectedCountries" class="chip-row"></div>
+                        </div>
+                        <div>
+                            <span class="summary-label">Selected cities</span>
+                            <div id="selectedCities" class="chip-row"></div>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="card metrics-card">
+                    <div class="card-header">
+                        <h2>Overview</h2>
+                        <p>Quick summary of the current comparison set.</p>
+                    </div>
+
+                    <div class="metric-grid">
+                        <div class="metric-box">
+                            <span class="metric-label">Cities selected</span>
+                            <span id="metricCities" class="metric-value"
+                                >0</span
+                            >
+                        </div>
+                        <div class="metric-box">
+                            <span class="metric-label">Countries selected</span>
+                            <span id="metricCountries" class="metric-value"
+                                >0</span
+                            >
+                        </div>
+                        <div class="metric-box">
+                            <span class="metric-label">Lowest rent city</span>
+                            <span
+                                id="metricLowestRent"
+                                class="metric-value metric-small"
+                                >—</span
+                            >
+                        </div>
+                        <div class="metric-box">
+                            <span class="metric-label">Highest QoL city</span>
+                            <span
+                                id="metricBestQol"
+                                class="metric-value metric-small"
+                                >—</span
+                            >
+                        </div>
+                    </div>
+                </section>
+
+                <section class="card table-card">
+                    <div class="card-header">
+                        <h2>Comparison table</h2>
+                        <p>
+                            Built from <code>/cities?ids=...&include=...</code>.
+                        </p>
+                    </div>
+
+                    <div id="tableEmptyState" class="empty-state">
+                        Select cities and click <strong>Compare</strong> to load
+                        data.
+                    </div>
+
+                    <div
+                        id="comparisonTableWrapper"
+                        class="table-wrapper hidden"
+                    >
+                        <table id="comparisonTable">
+                            <thead>
+                                <tr>
+                                    <th>City</th>
+                                    <th>Country</th>
+                                    <th>Cost of Living</th>
+                                    <th>Rent</th>
+                                    <th>Groceries</th>
+                                    <th>Restaurant</th>
+                                    <th>QoL</th>
+                                    <th>Safety</th>
+                                    <th>Health Care</th>
+                                </tr>
+                            </thead>
+                            <tbody></tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section class="card chart-card">
+                    <div class="card-header">
+                        <h2>Climate chart</h2>
+                        <p>Average monthly high temperature comparison.</p>
+                    </div>
+
+                    <div id="chartEmptyState" class="empty-state">
+                        Climate chart will appear after comparison data is
+                        loaded.
+                    </div>
+
+                    <div class="chart-wrapper">
+                        <canvas id="climateChart"></canvas>
+                    </div>
+                </section>
+            </main>
+        </div>
+    </body>
+</html>

--- a/ui/index.html
+++ b/ui/index.html
@@ -32,12 +32,22 @@
 
             <main class="dashboard-grid">
                 <section class="card filters-card">
-                    <div class="card-header">
-                        <h2>Filters</h2>
-                        <p>Select countries first, then cities.</p>
+                    <div class="card-header filters-header">
+                        <div>
+                            <h2>Filters</h2>
+                            <p>Select countries first, then cities.</p>
+                        </div>
+                        <button
+                            id="editFiltersBtn"
+                            class="btn btn-secondary hidden"
+                            type="button"
+                        >
+                            Edit filters
+                        </button>
                     </div>
 
-                    <div class="filters-grid">
+                    <div id="filtersBody" class="filters-body">
+                        <div class="filters-grid">
                         <div class="filter-block">
                             <label for="countrySearch">Search countries</label>
                             <input
@@ -58,6 +68,7 @@
                                 placeholder="Type city name..."
                             />
                             <div id="cityList" class="selection-list"></div>
+                        </div>
                         </div>
                     </div>
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -271,6 +271,32 @@
                         </table>
                     </div>
                 </section>
+
+                <section class="card indices-card">
+                    <div class="card-header">
+                        <h2>The Legatum Prosperity Index</h2>
+                        <p>Selected country comparison based on 2023 Legatum scores.</p>
+                    </div>
+
+                    <div id="legatumIndicesEmptyState" class="empty-state">
+                        Select cities and click <strong>Compare</strong> to
+                        load Legatum indices.
+                    </div>
+
+                    <div
+                        id="legatumIndicesWrapper"
+                        class="table-wrapper indices-table-wrapper hidden"
+                    >
+                        <table id="legatumIndicesTable" class="indices-table">
+                            <thead>
+                                <tr id="legatumIndicesHeadRow">
+                                    <th>Index</th>
+                                </tr>
+                            </thead>
+                            <tbody id="legatumIndicesBody"></tbody>
+                        </table>
+                    </div>
+                </section>
             </main>
         </div>
     </body>

--- a/ui/index.html
+++ b/ui/index.html
@@ -144,17 +144,79 @@
 
                 <section class="card chart-card">
                     <div class="card-header">
-                        <h2>Climate chart</h2>
-                        <p>Average monthly high temperature comparison.</p>
+                        <h2>Climate</h2>
+                        <p>Monthly climate comparison across selected cities.</p>
                     </div>
 
                     <div id="chartEmptyState" class="empty-state">
-                        Climate chart will appear after comparison data is
+                        Climate charts will appear after comparison data is
                         loaded.
                     </div>
 
-                    <div class="chart-wrapper">
-                        <canvas id="climateChart"></canvas>
+                    <div id="climateChartsGrid" class="climate-charts-grid hidden">
+                        <div class="climate-chart-card climate-chart-card-wide">
+                            <div class="climate-chart-head">
+                                <h3>Temperature</h3>
+                                <p>High temperature uses solid lines, low temperature uses dashed lines.</p>
+                            </div>
+                            <div class="climate-chart-wrapper climate-chart-wrapper-wide">
+                                <canvas id="climateTemperatureChart"></canvas>
+                            </div>
+                        </div>
+
+                        <div class="climate-chart-card">
+                            <div class="climate-chart-head">
+                                <h3>Sunshine Hours</h3>
+                            </div>
+                            <div class="climate-chart-wrapper">
+                                <canvas id="climateSunshineChart"></canvas>
+                            </div>
+                        </div>
+
+                        <div class="climate-chart-card">
+                            <div class="climate-chart-head">
+                                <h3>Daylight Hours</h3>
+                            </div>
+                            <div class="climate-chart-wrapper">
+                                <canvas id="climateDaylightChart"></canvas>
+                            </div>
+                        </div>
+
+                        <div class="climate-chart-card">
+                            <div class="climate-chart-head">
+                                <h3>Humidity</h3>
+                            </div>
+                            <div class="climate-chart-wrapper">
+                                <canvas id="climateHumidityChart"></canvas>
+                            </div>
+                        </div>
+
+                        <div class="climate-chart-card">
+                            <div class="climate-chart-head">
+                                <h3>Rainfall</h3>
+                            </div>
+                            <div class="climate-chart-wrapper">
+                                <canvas id="climateRainfallChart"></canvas>
+                            </div>
+                        </div>
+
+                        <div class="climate-chart-card">
+                            <div class="climate-chart-head">
+                                <h3>Wind</h3>
+                            </div>
+                            <div class="climate-chart-wrapper">
+                                <canvas id="climateWindChart"></canvas>
+                            </div>
+                        </div>
+
+                        <div class="climate-chart-card">
+                            <div class="climate-chart-head">
+                                <h3>UV Index</h3>
+                            </div>
+                            <div class="climate-chart-wrapper">
+                                <canvas id="climateUVIndexChart"></canvas>
+                            </div>
+                        </div>
                     </div>
                 </section>
             </main>

--- a/ui/index.html
+++ b/ui/index.html
@@ -245,6 +245,32 @@
                         </table>
                     </div>
                 </section>
+
+                <section class="card indices-card">
+                    <div class="card-header">
+                        <h2>Numbeo Indices by Country</h2>
+                        <p>Country comparison for the countries of the selected cities.</p>
+                    </div>
+
+                    <div id="countryNumbeoIndicesEmptyState" class="empty-state">
+                        Select cities and click <strong>Compare</strong> to
+                        load country indices.
+                    </div>
+
+                    <div
+                        id="countryNumbeoIndicesWrapper"
+                        class="table-wrapper indices-table-wrapper hidden"
+                    >
+                        <table id="countryNumbeoIndicesTable" class="indices-table">
+                            <thead>
+                                <tr id="countryNumbeoIndicesHeadRow">
+                                    <th>Index</th>
+                                </tr>
+                            </thead>
+                            <tbody id="countryNumbeoIndicesBody"></tbody>
+                        </table>
+                    </div>
+                </section>
             </main>
         </div>
     </body>

--- a/ui/index.html
+++ b/ui/index.html
@@ -115,7 +115,7 @@
 
                 <section class="card cost-breakdown-card">
                     <div class="card-header">
-                        <h2>Cost of Living Breakdown</h2>
+                        <h2>Cost of Living</h2>
                         <p>
                             Click an item row to sort cities by that value.
                         </p>

--- a/ui/index.html
+++ b/ui/index.html
@@ -160,6 +160,35 @@
                     </div>
                 </section>
 
+                <section class="card cost-breakdown-card">
+                    <div class="card-header">
+                        <h2>Cost of Living Breakdown</h2>
+                        <p>
+                            Row-based placeholder cost items, structured like
+                            <code>numbeo_cost.prices</code>.
+                        </p>
+                    </div>
+
+                    <div id="costBreakdownEmptyState" class="empty-state">
+                        Select cities and click <strong>Compare</strong> to
+                        build a cost breakdown table.
+                    </div>
+
+                    <div
+                        id="costBreakdownWrapper"
+                        class="table-wrapper cost-breakdown-wrapper hidden"
+                    >
+                        <table id="costBreakdownTable" class="cost-breakdown-table">
+                            <thead>
+                                <tr id="costBreakdownHeadRow">
+                                    <th>Item</th>
+                                </tr>
+                            </thead>
+                            <tbody id="costBreakdownBody"></tbody>
+                        </table>
+                    </div>
+                </section>
+
                 <section class="card chart-card">
                     <div class="card-header">
                         <h2>Climate chart</h2>

--- a/ui/index.html
+++ b/ui/index.html
@@ -20,14 +20,6 @@
                     </p>
                 </div>
 
-                <div class="topbar-actions">
-                    <button id="compareBtn" class="btn btn-primary">
-                        Compare
-                    </button>
-                    <button id="resetBtn" class="btn btn-secondary">
-                        Reset
-                    </button>
-                </div>
             </header>
 
             <main class="dashboard-grid">
@@ -37,13 +29,29 @@
                             <h2>Filters</h2>
                             <p>Select countries first, then cities.</p>
                         </div>
-                        <button
-                            id="editFiltersBtn"
-                            class="btn btn-secondary hidden"
-                            type="button"
-                        >
-                            Edit filters
-                        </button>
+                        <div class="filters-actions">
+                            <button
+                                id="compareBtn"
+                                class="btn btn-primary"
+                                type="button"
+                            >
+                                Compare
+                            </button>
+                            <button
+                                id="resetBtn"
+                                class="btn btn-secondary"
+                                type="button"
+                            >
+                                Reset
+                            </button>
+                            <button
+                                id="editFiltersBtn"
+                                class="btn btn-secondary hidden"
+                                type="button"
+                            >
+                                Edit filters
+                            </button>
+                        </div>
                     </div>
 
                     <div id="filtersBody" class="filters-body">

--- a/ui/index.html
+++ b/ui/index.html
@@ -164,8 +164,7 @@
                     <div class="card-header">
                         <h2>Cost of Living Breakdown</h2>
                         <p>
-                            Row-based placeholder cost items, structured like
-                            <code>numbeo_cost.prices</code>.
+                            Click an item row to sort cities by that value.
                         </p>
                     </div>
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -219,6 +219,32 @@
                         </div>
                     </div>
                 </section>
+
+                <section class="card indices-card">
+                    <div class="card-header">
+                        <h2>Numbeo Indices by City</h2>
+                        <p>Selected city comparison based on Numbeo city indices.</p>
+                    </div>
+
+                    <div id="numbeoIndicesEmptyState" class="empty-state">
+                        Select cities and click <strong>Compare</strong> to
+                        load city indices.
+                    </div>
+
+                    <div
+                        id="numbeoIndicesWrapper"
+                        class="table-wrapper indices-table-wrapper hidden"
+                    >
+                        <table id="numbeoIndicesTable" class="indices-table">
+                            <thead>
+                                <tr id="numbeoIndicesHeadRow">
+                                    <th>Index</th>
+                                </tr>
+                            </thead>
+                            <tbody id="numbeoIndicesBody"></tbody>
+                        </table>
+                    </div>
+                </section>
             </main>
         </div>
     </body>

--- a/ui/index.html
+++ b/ui/index.html
@@ -12,15 +12,12 @@
     <body>
         <div class="app-shell">
             <header class="topbar">
-                <div>
-                    <p class="eyebrow">Relohelper</p>
-                    <h1>City Comparison Dashboard</h1>
+                <div class="page-header">
+                    <h1>Relohelper</h1>
                     <p class="subtitle">
-                        Compare multiple cities by cost of living, indices, and
-                        climate.
+                        Compare cities by cost, climate, and quality of life.
                     </p>
                 </div>
-
             </header>
 
             <main class="dashboard-grid">

--- a/ui/index.html
+++ b/ui/index.html
@@ -74,52 +74,33 @@
 
                     <div class="selected-summary">
                         <div>
-                            <span class="summary-label"
-                                >Selected countries</span
-                            >
+                            <div class="summary-head">
+                                <span class="summary-label"
+                                    >Selected countries</span
+                                >
+                                <span
+                                    id="selectedCountriesCount"
+                                    class="summary-count"
+                                    >0</span
+                                >
+                            </div>
                             <div id="selectedCountries" class="chip-row"></div>
                         </div>
                         <div>
-                            <span class="summary-label">Selected cities</span>
+                            <div class="summary-head">
+                                <span class="summary-label">Selected cities</span>
+                                <span
+                                    id="selectedCitiesCount"
+                                    class="summary-count"
+                                    >0</span
+                                >
+                                <span
+                                    id="selectedCitiesLimitHint"
+                                    class="summary-limit-hint hidden"
+                                    >Limit reached (20 cities)</span
+                                >
+                            </div>
                             <div id="selectedCities" class="chip-row"></div>
-                        </div>
-                    </div>
-                </section>
-
-                <section class="card metrics-card">
-                    <div class="card-header">
-                        <h2>Overview</h2>
-                        <p>Quick summary of the current comparison set.</p>
-                    </div>
-
-                    <div class="metric-grid">
-                        <div class="metric-box">
-                            <span class="metric-label">Cities selected</span>
-                            <span id="metricCities" class="metric-value"
-                                >0</span
-                            >
-                        </div>
-                        <div class="metric-box">
-                            <span class="metric-label">Countries selected</span>
-                            <span id="metricCountries" class="metric-value"
-                                >0</span
-                            >
-                        </div>
-                        <div class="metric-box">
-                            <span class="metric-label">Lowest rent city</span>
-                            <span
-                                id="metricLowestRent"
-                                class="metric-value metric-small"
-                                >—</span
-                            >
-                        </div>
-                        <div class="metric-box">
-                            <span class="metric-label">Highest QoL city</span>
-                            <span
-                                id="metricBestQol"
-                                class="metric-value metric-small"
-                                >—</span
-                            >
                         </div>
                     </div>
                 </section>

--- a/ui/index.html
+++ b/ui/index.html
@@ -105,42 +105,6 @@
                     </div>
                 </section>
 
-                <section class="card table-card">
-                    <div class="card-header">
-                        <h2>Comparison table</h2>
-                        <p>
-                            Built from <code>/cities?ids=...&include=...</code>.
-                        </p>
-                    </div>
-
-                    <div id="tableEmptyState" class="empty-state">
-                        Select cities and click <strong>Compare</strong> to load
-                        data.
-                    </div>
-
-                    <div
-                        id="comparisonTableWrapper"
-                        class="table-wrapper hidden"
-                    >
-                        <table id="comparisonTable">
-                            <thead>
-                                <tr>
-                                    <th>City</th>
-                                    <th>Country</th>
-                                    <th>Cost of Living</th>
-                                    <th>Rent</th>
-                                    <th>Groceries</th>
-                                    <th>Restaurant</th>
-                                    <th>QoL</th>
-                                    <th>Safety</th>
-                                    <th>Health Care</th>
-                                </tr>
-                            </thead>
-                            <tbody></tbody>
-                        </table>
-                    </div>
-                </section>
-
                 <section class="card cost-breakdown-card">
                     <div class="card-header">
                         <h2>Cost of Living Breakdown</h2>

--- a/ui/index.html
+++ b/ui/index.html
@@ -273,9 +273,27 @@
                 </section>
 
                 <section class="card indices-card">
-                    <div class="card-header">
-                        <h2>The Legatum Prosperity Index</h2>
-                        <p>Selected country comparison based on 2023 Legatum scores.</p>
+                    <div class="card-header indices-header-with-toggle">
+                        <div>
+                            <h2>The Legatum Prosperity Index</h2>
+                            <p>Compare selected countries by Legatum scores or ranks.</p>
+                        </div>
+                        <div class="table-mode-toggle" role="group" aria-label="Legatum metric mode">
+                            <button
+                                id="legatumScoreToggle"
+                                class="table-mode-toggle-btn is-active"
+                                type="button"
+                            >
+                                Score
+                            </button>
+                            <button
+                                id="legatumRankToggle"
+                                class="table-mode-toggle-btn"
+                                type="button"
+                            >
+                                Rank
+                            </button>
+                        </div>
                     </div>
 
                     <div id="legatumIndicesEmptyState" class="empty-state">

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -340,6 +340,22 @@ h1 {
     text-align: left;
 }
 
+.table-city-name {
+    display: inline-block;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.table-city-meta {
+    display: inline-block;
+    margin-top: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    letter-spacing: 0.03em;
+    color: #7c8aa0;
+}
+
 .cost-breakdown-table thead th:first-child,
 .cost-breakdown-table tbody td:first-child {
     position: sticky;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -159,6 +159,41 @@ h1 {
     flex-shrink: 0;
 }
 
+.indices-header-with-toggle {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.table-mode-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: #f8fafc;
+    flex-shrink: 0;
+}
+
+.table-mode-toggle-btn {
+    border: none;
+    background: transparent;
+    color: var(--muted);
+    padding: 8px 12px;
+    border-radius: 999px;
+    font-size: 12px;
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.table-mode-toggle-btn.is-active {
+    background: white;
+    color: var(--primary-dark);
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+}
+
 .card-header h2 {
     margin: 0 0 8px 0;
     font-size: 20px;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -430,30 +430,41 @@ h1 {
 
 .cost-breakdown-table {
     min-width: 940px;
+    table-layout: fixed;
 }
 
 .cost-breakdown-table thead th {
     text-align: right;
+    width: 138px;
 }
 
 .cost-breakdown-table thead th:first-child {
     text-align: left;
+    width: var(--breakdown-item-col-width);
 }
 
 .table-city-name {
     display: inline-block;
+    max-width: 100%;
     font-size: 14px;
     font-weight: 600;
     color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .table-city-meta {
     display: inline-block;
     margin-top: 4px;
+    max-width: 100%;
     font-size: 12px;
     font-weight: 500;
     letter-spacing: 0.03em;
     color: #7c8aa0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .cost-breakdown-table thead th:first-child,

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -680,12 +680,123 @@ tbody tr:hover {
 
 .chart-wrapper {
     margin-top: 8px;
-    min-height: 360px;
 }
 
-canvas {
+.climate-charts-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+}
+
+.climate-chart-card {
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    background: #fbfcff;
+    padding: 16px;
+}
+
+.climate-chart-card-wide {
+    grid-column: 1 / -1;
+}
+
+.climate-chart-head {
+    margin-bottom: 12px;
+}
+
+.climate-chart-head h3 {
+    margin: 0;
+    font-size: 16px;
+}
+
+.climate-chart-head p {
+    margin: 6px 0 0 0;
+    font-size: 13px;
+    color: var(--muted);
+}
+
+.climate-chart-wrapper {
+    position: relative;
+    height: 260px;
+}
+
+.climate-chart-wrapper-wide {
+    height: 396px;
+}
+
+.climate-chart-wrapper canvas {
     width: 100% !important;
-    height: 360px !important;
+    height: 100% !important;
+}
+
+.chart-tooltip {
+    position: absolute;
+    z-index: 20;
+    min-width: 180px;
+    max-width: 260px;
+    padding: 10px 12px;
+    border-radius: 12px;
+    background: rgba(15, 23, 42, 0.94);
+    color: #e2e8f0;
+    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.24);
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(4px);
+    transition:
+        opacity 0.12s ease,
+        transform 0.12s ease;
+}
+
+.chart-tooltip.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.chart-tooltip-row {
+    display: grid;
+    grid-template-columns: 14px minmax(0, 1fr);
+    gap: 10px;
+    align-items: start;
+}
+
+.chart-tooltip-swatch {
+    display: block;
+    width: 14px;
+    height: 14px;
+    margin-top: 3px;
+    border-radius: 4px;
+}
+
+.chart-tooltip-city {
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.25;
+    color: #f8fafc;
+}
+
+.chart-tooltip-text {
+    margin-top: 6px;
+    font-size: 13px;
+    line-height: 1.35;
+    color: #cbd5e1;
+}
+
+.chart-tooltip-metric {
+    display: grid;
+    grid-template-columns: 42px minmax(0, 1fr);
+    gap: 8px;
+    margin-top: 4px;
+    font-size: 13px;
+    line-height: 1.35;
+    padding-left: 8px;
+}
+
+.chart-tooltip-key {
+    color: #94a3b8;
+    font-weight: 600;
+}
+
+.chart-tooltip-value {
+    color: #e2e8f0;
 }
 
 .hidden {
@@ -701,7 +812,7 @@ canvas {
 @media (max-width: 1100px) {
     .dashboard-grid,
     .filters-grid,
-    .metric-grid {
+    .climate-charts-grid {
         grid-template-columns: 1fr;
     }
 
@@ -717,5 +828,9 @@ canvas {
     .filters-header {
         flex-direction: column;
         align-items: stretch;
+    }
+
+    .climate-chart-card-wide {
+        grid-column: auto;
     }
 }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -147,6 +147,13 @@ h1 {
     margin-bottom: 18px;
 }
 
+.filters-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
 .card-header h2 {
     margin: 0 0 8px 0;
     font-size: 20px;
@@ -163,7 +170,7 @@ h1 {
     gap: 18px;
 }
 
-.filter-block label {
+.filter-block > label {
     display: block;
     font-size: 13px;
     font-weight: 600;
@@ -202,6 +209,7 @@ h1 {
     gap: 10px;
     padding: 10px 8px;
     border-radius: 10px;
+    cursor: pointer;
 }
 
 .selection-item:hover {
@@ -210,12 +218,16 @@ h1 {
 
 .selection-item input {
     accent-color: var(--primary);
+    margin: 0;
+    flex: 0 0 auto;
 }
 
 .selection-item-main {
     display: flex;
     flex-direction: column;
     gap: 3px;
+    min-width: 0;
+    flex: 1 1 auto;
 }
 
 .selection-title {
@@ -233,6 +245,18 @@ h1 {
     grid-template-columns: 1fr;
     gap: 16px;
     margin-top: 18px;
+}
+
+.filters-card.is-collapsed {
+    padding-bottom: 18px;
+}
+
+.filters-card.is-collapsed .card-header {
+    margin-bottom: 14px;
+}
+
+.filters-card.is-collapsed .filters-body {
+    display: none;
 }
 
 .summary-label {
@@ -370,5 +394,10 @@ canvas {
 
     .topbar-actions {
         justify-content: flex-start;
+    }
+
+    .filters-header {
+        flex-direction: column;
+        align-items: stretch;
     }
 }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -84,12 +84,6 @@ h1 {
     max-width: 760px;
 }
 
-.topbar-actions {
-    display: flex;
-    gap: 12px;
-    flex-shrink: 0;
-}
-
 .btn {
     border: none;
     border-radius: 12px;
@@ -155,6 +149,12 @@ h1 {
     justify-content: space-between;
     gap: 16px;
     align-items: flex-start;
+}
+
+.filters-actions {
+    display: flex;
+    gap: 12px;
+    flex-shrink: 0;
 }
 
 .card-header h2 {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -442,8 +442,43 @@ h1 {
 
 .cost-item-name {
     min-width: var(--breakdown-item-col-width);
-    font-weight: 600;
+    padding: 0;
+}
+
+.cost-item-sort {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 0 16px;
+    border: none;
+    background: transparent;
     color: var(--text);
+    font: inherit;
+    font-weight: 600;
+    text-align: left;
+    cursor: pointer;
+}
+
+.cost-item-sort:hover {
+    background: #fafcff;
+}
+
+.cost-item-sort-indicator {
+    color: #94a3b8;
+    font-size: 14px;
+    flex: 0 0 auto;
+    font-weight: 400;
+    min-width: 14px;
+    text-align: center;
+}
+
+.cost-item-sort.is-active .cost-item-sort-indicator {
+    color: #1d4ed8;
+    font-weight: 700;
+    font-size: 16px;
+    text-shadow: 0 0 0 currentColor;
 }
 
 .cost-value {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -171,6 +171,12 @@ h1 {
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 18px;
+    align-items: stretch;
+}
+
+.filter-block {
+    display: flex;
+    flex-direction: column;
 }
 
 .filter-block > label {
@@ -197,8 +203,7 @@ h1 {
 
 .selection-list {
     margin-top: 12px;
-    min-height: 240px;
-    max-height: 320px;
+    height: 320px;
     overflow: auto;
     border: 1px solid var(--line);
     border-radius: var(--radius-sm);
@@ -206,6 +211,7 @@ h1 {
     padding: 10px;
     display: flex;
     flex-direction: column;
+    flex: 1 1 auto;
 }
 
 .selection-list-empty {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -250,6 +250,53 @@ h1 {
     margin-top: 18px;
 }
 
+.summary-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: flex-start;
+    gap: 12px;
+    margin-bottom: 8px;
+    flex-wrap: nowrap;
+}
+
+.summary-label {
+    line-height: 1.2;
+}
+
+.summary-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 32px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: #eff6ff;
+    color: #1d4ed8;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+    flex: 0 0 auto;
+}
+
+.summary-count.is-warning {
+    background: #fee2e2;
+    color: #b91c1c;
+}
+
+.summary-limit-hint {
+    display: inline-flex;
+    align-items: center;
+    color: #b91c1c;
+    background: #fff1f2;
+    border: 1px solid #fecdd3;
+    border-radius: 999px;
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    flex: 0 0 auto;
+}
+
 .filters-card.is-collapsed {
     padding-bottom: 18px;
 }

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -293,6 +293,13 @@ h1 {
     font-weight: 600;
 }
 
+.selection-title-meta {
+    margin-left: 8px;
+    color: #7c8aa0;
+    font-weight: 500;
+    letter-spacing: -0.01em;
+}
+
 .selection-subtitle {
     font-size: 12px;
     color: var(--muted);

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -12,6 +12,7 @@
     --radius-sm: 12px;
     --success: #059669;
     --breakdown-item-col-width: 380px;
+    --indices-item-col-width: 270px;
     --breakdown-meta-col-width: 132px;
 }
 
@@ -132,7 +133,8 @@ h1 {
 .filters-card,
 .table-card,
 .cost-breakdown-card,
-.chart-card {
+.chart-card,
+.indices-card {
     grid-column: 1 / -1;
 }
 
@@ -428,7 +430,16 @@ h1 {
     max-height: 840px;
 }
 
+.indices-table-wrapper {
+    max-height: 720px;
+}
+
 .cost-breakdown-table {
+    min-width: 940px;
+    table-layout: fixed;
+}
+
+.indices-table {
     min-width: 940px;
     table-layout: fixed;
 }
@@ -438,9 +449,19 @@ h1 {
     width: 124px;
 }
 
+.indices-table thead th {
+    text-align: right;
+    width: 124px;
+}
+
 .cost-breakdown-table thead th:first-child {
     text-align: left;
     width: var(--breakdown-item-col-width);
+}
+
+.indices-table thead th:first-child {
+    text-align: left;
+    width: var(--indices-item-col-width);
 }
 
 .table-city-name {
@@ -474,7 +495,18 @@ h1 {
     background: white;
 }
 
+.indices-table thead th:first-child,
+.indices-table tbody td:first-child {
+    position: sticky;
+    left: 0;
+    background: white;
+}
+
 .cost-breakdown-table tbody td:first-child {
+    z-index: 1;
+}
+
+.indices-table tbody td:first-child {
     z-index: 1;
 }
 
@@ -482,7 +514,16 @@ h1 {
     z-index: 3;
 }
 
+.indices-table thead th {
+    z-index: 3;
+}
+
 .cost-breakdown-table thead th:first-child {
+    z-index: 4;
+    background: #f8fafc;
+}
+
+.indices-table thead th:first-child {
     z-index: 4;
     background: #f8fafc;
 }
@@ -637,6 +678,24 @@ h1 {
 .cost-breakdown-table tbody td {
     padding-top: 11px;
     padding-bottom: 11px;
+}
+
+.indices-table tbody td {
+    padding-top: 11px;
+    padding-bottom: 11px;
+}
+
+.indices-item-name {
+    min-width: var(--indices-item-col-width);
+    padding: 0;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.indices-value {
+    text-align: right;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
 }
 
 table {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -435,7 +435,7 @@ h1 {
 
 .cost-breakdown-table thead th {
     text-align: right;
-    width: 138px;
+    width: 124px;
 }
 
 .cost-breakdown-table thead th:first-child {
@@ -449,9 +449,9 @@ h1 {
     font-size: 14px;
     font-weight: 600;
     color: var(--text);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    line-height: 1.2;
+    white-space: normal;
+    overflow-wrap: anywhere;
 }
 
 .table-city-meta {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -11,6 +11,8 @@
     --radius: 18px;
     --radius-sm: 12px;
     --success: #059669;
+    --breakdown-item-col-width: 380px;
+    --breakdown-meta-col-width: 132px;
 }
 
 * {
@@ -135,6 +137,7 @@ h1 {
 
 .filters-card,
 .table-card,
+.cost-breakdown-card,
 .chart-card {
     grid-column: 1 / -1;
 }
@@ -319,6 +322,159 @@ h1 {
     overflow: auto;
     border: 1px solid var(--line);
     border-radius: 14px;
+}
+
+.cost-breakdown-wrapper {
+    max-height: 840px;
+}
+
+.cost-breakdown-table {
+    min-width: 940px;
+}
+
+.cost-breakdown-table thead th {
+    text-align: right;
+}
+
+.cost-breakdown-table thead th:first-child {
+    text-align: left;
+}
+
+.cost-breakdown-table thead th:first-child,
+.cost-breakdown-table tbody td:first-child {
+    position: sticky;
+    left: 0;
+    background: white;
+}
+
+.cost-breakdown-table tbody td:first-child {
+    z-index: 1;
+}
+
+.cost-breakdown-table thead th {
+    z-index: 3;
+}
+
+.cost-breakdown-table thead th:first-child {
+    z-index: 4;
+    background: #f8fafc;
+}
+
+.cost-group-row td {
+    padding: 0;
+    background: #f8fafc;
+    border-top: 1px solid var(--line);
+    border-bottom: 1px solid var(--line);
+}
+
+.cost-group-cell {
+    background: #f8fafc;
+}
+
+.cost-group-cell-main {
+    position: sticky;
+    left: 0;
+    z-index: 4;
+    width: var(--breakdown-item-col-width);
+    min-width: var(--breakdown-item-col-width);
+}
+
+.cost-group-cell-fill {
+    background: #f8fafc;
+    position: relative;
+    padding: 0;
+}
+
+.cost-group-toggle {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 16px;
+    padding: 11px 16px;
+    border: none;
+    background: transparent;
+    color: var(--muted);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.cost-group-toggle:hover {
+    background: rgba(59, 130, 246, 0.05);
+}
+
+.cost-group-label {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.cost-group-count {
+    position: sticky;
+    right: 0;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    width: var(--breakdown-meta-col-width);
+    min-width: var(--breakdown-meta-col-width);
+    margin-left: auto;
+    padding: 11px 16px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--muted);
+    white-space: nowrap;
+    background: #f8fafc;
+}
+
+.cost-group-arrow {
+    font-size: 12px;
+    color: var(--primary);
+    transition: transform 0.15s ease;
+}
+
+.cost-group-row.is-collapsed .cost-group-arrow {
+    transform: rotate(-90deg);
+}
+
+.cost-item-name {
+    min-width: var(--breakdown-item-col-width);
+    font-weight: 600;
+    color: var(--text);
+}
+
+.cost-value {
+    text-align: right;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+}
+
+.cost-value-low {
+    background: #dff4e7;
+    color: #0f5f35;
+}
+
+.cost-value-low-soft {
+    background: #f6fbf7;
+    color: var(--text);
+}
+
+.cost-value-high {
+    background: #fae1e4;
+    color: #963741;
+}
+
+.cost-value-high-soft {
+    background: #fdf6f7;
+    color: var(--text);
+}
+
+.cost-breakdown-table tbody td {
+    padding-top: 11px;
+    padding-bottom: 11px;
 }
 
 table {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1,0 +1,374 @@
+:root {
+    --bg: #f5f7fb;
+    --card: #ffffff;
+    --card-muted: #f8fafc;
+    --text: #172033;
+    --muted: #64748b;
+    --line: #e2e8f0;
+    --primary: #3b82f6;
+    --primary-dark: #2563eb;
+    --shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+    --radius: 18px;
+    --radius-sm: 12px;
+    --success: #059669;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        "Segoe UI",
+        sans-serif;
+}
+
+body {
+    min-height: 100vh;
+}
+
+code {
+    font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+        "Liberation Mono", monospace;
+    background: #eff6ff;
+    color: #1d4ed8;
+    padding: 0.1rem 0.35rem;
+    border-radius: 6px;
+}
+
+.app-shell {
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 24px;
+}
+
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    align-items: flex-start;
+    margin-bottom: 24px;
+}
+
+.eyebrow {
+    margin: 0 0 8px 0;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--primary);
+}
+
+h1 {
+    margin: 0;
+    font-size: 34px;
+    line-height: 1.15;
+}
+
+.subtitle {
+    margin: 10px 0 0 0;
+    color: var(--muted);
+    max-width: 760px;
+}
+
+.topbar-actions {
+    display: flex;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.btn {
+    border: none;
+    border-radius: 12px;
+    padding: 12px 18px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition:
+        transform 0.15s ease,
+        background 0.15s ease,
+        opacity 0.15s ease;
+}
+
+.btn:hover {
+    transform: translateY(-1px);
+}
+
+.btn-primary {
+    background: var(--primary);
+    color: white;
+}
+
+.btn-primary:hover {
+    background: var(--primary-dark);
+}
+
+.btn-secondary {
+    background: white;
+    color: var(--text);
+    border: 1px solid var(--line);
+}
+
+.dashboard-grid {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 24px;
+}
+
+.card {
+    background: var(--card);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    padding: 22px;
+}
+
+.filters-card,
+.table-card,
+.chart-card {
+    grid-column: 1 / -1;
+}
+
+.metrics-card {
+    grid-column: 1 / -1;
+}
+
+.card-header {
+    margin-bottom: 18px;
+}
+
+.card-header h2 {
+    margin: 0 0 8px 0;
+    font-size: 20px;
+}
+
+.card-header p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.filters-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 18px;
+}
+
+.filter-block label {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: var(--muted);
+}
+
+.text-input {
+    width: 100%;
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 12px 14px;
+    font-size: 14px;
+    outline: none;
+    background: white;
+}
+
+.text-input:focus {
+    border-color: var(--primary);
+}
+
+.selection-list {
+    margin-top: 12px;
+    min-height: 240px;
+    max-height: 320px;
+    overflow: auto;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    background: var(--card-muted);
+    padding: 10px;
+}
+
+.selection-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 8px;
+    border-radius: 10px;
+}
+
+.selection-item:hover {
+    background: white;
+}
+
+.selection-item input {
+    accent-color: var(--primary);
+}
+
+.selection-item-main {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.selection-title {
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.selection-subtitle {
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.selected-summary {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 16px;
+    margin-top: 18px;
+}
+
+.summary-label {
+    display: block;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--muted);
+    margin-bottom: 8px;
+}
+
+.chip-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.chip {
+    display: inline-flex;
+    align-items: center;
+    min-height: 30px;
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: #e8f0ff;
+    color: #1d4ed8;
+    font-size: 13px;
+    font-weight: 600;
+}
+
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 16px;
+}
+
+.metric-box {
+    padding: 18px;
+    background: var(--card-muted);
+    border-radius: 16px;
+    border: 1px solid var(--line);
+}
+
+.metric-label {
+    display: block;
+    font-size: 13px;
+    color: var(--muted);
+    margin-bottom: 8px;
+}
+
+.metric-value {
+    font-size: 28px;
+    font-weight: 700;
+}
+
+.metric-small {
+    font-size: 18px;
+    line-height: 1.3;
+}
+
+.table-wrapper {
+    overflow: auto;
+    border: 1px solid var(--line);
+    border-radius: 14px;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 1100px;
+    background: white;
+}
+
+thead th {
+    position: sticky;
+    top: 0;
+    background: #f8fafc;
+    z-index: 1;
+    text-align: left;
+    font-size: 13px;
+    color: var(--muted);
+    font-weight: 700;
+    border-bottom: 1px solid var(--line);
+    padding: 14px 16px;
+}
+
+tbody td {
+    padding: 14px 16px;
+    border-bottom: 1px solid #eef2f7;
+    font-size: 14px;
+}
+
+tbody tr:hover {
+    background: #fafcff;
+}
+
+.empty-state {
+    border: 1px dashed var(--line);
+    border-radius: 14px;
+    padding: 26px;
+    text-align: center;
+    color: var(--muted);
+    background: var(--card-muted);
+}
+
+.chart-wrapper {
+    margin-top: 8px;
+    min-height: 360px;
+}
+
+canvas {
+    width: 100% !important;
+    height: 360px !important;
+}
+
+.hidden {
+    display: none;
+}
+
+.status-note {
+    margin-top: 10px;
+    font-size: 13px;
+    color: var(--muted);
+}
+
+@media (max-width: 1100px) {
+    .dashboard-grid,
+    .filters-grid,
+    .metric-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .topbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .topbar-actions {
+        justify-content: flex-start;
+    }
+}

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -733,6 +733,110 @@ h1 {
     font-variant-numeric: tabular-nums;
 }
 
+.legatum-tooltip {
+    position: fixed;
+    z-index: 40;
+    min-width: 280px;
+    max-width: 320px;
+    padding: 14px 14px 12px;
+    border: 1px solid rgba(148, 163, 184, 0.24);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.98);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
+    backdrop-filter: blur(8px);
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(4px);
+    transition:
+        opacity 0.12s ease,
+        transform 0.12s ease;
+}
+
+.legatum-tooltip.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.legatum-tooltip-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text);
+}
+
+.legatum-tooltip-subtitle {
+    margin-top: 4px;
+    font-size: 12px;
+    color: var(--muted);
+}
+
+.legatum-tooltip-current {
+    margin-top: 10px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.legatum-tooltip-chart {
+    margin-top: 10px;
+}
+
+.legatum-tooltip-sparkline {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.legatum-tooltip-grid {
+    stroke: rgba(148, 163, 184, 0.22);
+    stroke-width: 1;
+}
+
+.legatum-tooltip-grid-mid {
+    stroke: rgba(148, 163, 184, 0.14);
+}
+
+.legatum-tooltip-axis-tick {
+    stroke: rgba(100, 116, 139, 0.5);
+    stroke-width: 1;
+}
+
+.legatum-tooltip-axis-tick-mid {
+    stroke: rgba(100, 116, 139, 0.34);
+}
+
+.legatum-tooltip-y-label {
+    fill: #64748b;
+    font-size: 10px;
+    font-weight: 600;
+}
+
+.legatum-tooltip-y-label-mid {
+    fill: rgba(100, 116, 139, 0.75);
+    font-size: 9px;
+    font-weight: 500;
+}
+
+.legatum-tooltip-x-label {
+    fill: #64748b;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+.legatum-tooltip-x-label-mid {
+    fill: rgba(100, 116, 139, 0.78);
+    font-size: 10px;
+    font-weight: 500;
+}
+
+.legatum-tooltip-axis {
+    display: flex;
+    justify-content: space-between;
+    margin-top: 4px;
+    font-size: 11px;
+    color: #64748b;
+    font-weight: 600;
+}
+
 table {
     width: 100%;
     border-collapse: collapse;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -53,7 +53,7 @@ code {
 .app-shell {
     max-width: 1600px;
     margin: 0 auto;
-    padding: 24px;
+    padding: 24px 24px 48px;
 }
 
 .topbar {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -57,32 +57,29 @@ code {
 }
 
 .topbar {
-    display: flex;
-    justify-content: space-between;
-    gap: 24px;
-    align-items: flex-start;
     margin-bottom: 24px;
 }
 
-.eyebrow {
-    margin: 0 0 8px 0;
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--primary);
+.page-header {
+    max-width: 720px;
 }
 
 h1 {
     margin: 0;
-    font-size: 34px;
-    line-height: 1.15;
+    font-size: 38px;
+    line-height: 1.08;
+    letter-spacing: -0.025em;
+    color: #0f172a;
+    font-weight: 700;
 }
 
 .subtitle {
-    margin: 10px 0 0 0;
+    margin: 12px 0 0 0;
     color: var(--muted);
-    max-width: 760px;
+    max-width: 560px;
+    font-size: 15px;
+    line-height: 1.45;
+    font-weight: 400;
 }
 
 .btn {
@@ -517,6 +514,11 @@ h1 {
     overflow-wrap: anywhere;
 }
 
+.table-header-trigger {
+    display: inline-block;
+    max-width: 100%;
+}
+
 .table-city-meta {
     display: inline-block;
     margin-top: 4px;
@@ -740,6 +742,56 @@ h1 {
     font-variant-numeric: tabular-nums;
 }
 
+.header-info-tooltip {
+    position: fixed;
+    z-index: 42;
+    min-width: 144px;
+    max-width: 190px;
+    padding: 12px 12px 10px;
+    border: 1px solid rgba(203, 213, 225, 0.95);
+    border-radius: 12px;
+    background: rgba(248, 250, 252, 0.98);
+    color: var(--text);
+    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.14);
+    pointer-events: none;
+    opacity: 0;
+    transform: translateY(4px);
+    transition:
+        opacity 0.12s ease,
+        transform 0.12s ease;
+}
+
+.header-info-tooltip.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.header-info-title {
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1.3;
+    color: var(--text);
+}
+
+.header-info-row {
+    display: grid;
+    grid-template-columns: 30px minmax(0, 1fr);
+    gap: 8px;
+    margin-top: 6px;
+    font-size: 12px;
+    line-height: 1.35;
+}
+
+.header-info-key {
+    color: var(--muted);
+    font-weight: 600;
+}
+
+.header-info-value {
+    color: var(--text);
+    font-weight: 500;
+}
+
 .legatum-tooltip {
     position: fixed;
     z-index: 40;
@@ -936,13 +988,14 @@ tbody tr:hover {
 .chart-tooltip {
     position: absolute;
     z-index: 20;
-    min-width: 180px;
-    max-width: 260px;
+    min-width: 164px;
+    max-width: 210px;
     padding: 10px 12px;
     border-radius: 12px;
-    background: rgba(15, 23, 42, 0.94);
-    color: #e2e8f0;
-    box-shadow: 0 10px 24px rgba(15, 23, 42, 0.24);
+    background: rgba(248, 250, 252, 0.98);
+    color: var(--text);
+    border: 1px solid rgba(203, 213, 225, 0.95);
+    box-shadow: 0 14px 30px rgba(15, 23, 42, 0.14);
     pointer-events: none;
     opacity: 0;
     transform: translateY(4px);
@@ -975,14 +1028,14 @@ tbody tr:hover {
     font-size: 13px;
     font-weight: 700;
     line-height: 1.25;
-    color: #f8fafc;
+    color: var(--text);
 }
 
 .chart-tooltip-text {
     margin-top: 6px;
     font-size: 13px;
     line-height: 1.35;
-    color: #cbd5e1;
+    color: var(--muted);
 }
 
 .chart-tooltip-metric {
@@ -995,13 +1048,38 @@ tbody tr:hover {
     padding-left: 8px;
 }
 
+.chart-tooltip-metric-inline {
+    grid-template-columns: 28px minmax(0, 1fr);
+    margin-top: 6px;
+    padding-left: 0;
+}
+
+.chart-tooltip-metric-inline .chart-tooltip-key {
+    font-weight: 500;
+}
+
+.chart-tooltip-metric-inline .chart-tooltip-value {
+    color: var(--text);
+    font-weight: 500;
+}
+
 .chart-tooltip-key {
-    color: #94a3b8;
+    color: var(--muted);
     font-weight: 600;
 }
 
 .chart-tooltip-value {
-    color: #e2e8f0;
+    color: var(--text);
+}
+
+.chart-tooltip-value-number {
+    color: var(--text);
+    font-weight: 500;
+}
+
+.chart-tooltip-unit {
+    color: var(--muted);
+    font-weight: 500;
 }
 
 .hidden {
@@ -1021,13 +1099,8 @@ tbody tr:hover {
         grid-template-columns: 1fr;
     }
 
-    .topbar {
-        flex-direction: column;
-        align-items: stretch;
-    }
-
-    .topbar-actions {
-        justify-content: flex-start;
+    .page-header {
+        max-width: none;
     }
 
     .filters-header {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -204,6 +204,18 @@ h1 {
     border-radius: var(--radius-sm);
     background: var(--card-muted);
     padding: 10px;
+    display: flex;
+    flex-direction: column;
+}
+
+.selection-list-empty {
+    flex: 1 1 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 26px 16px;
+    text-align: center;
+    color: var(--muted);
 }
 
 .selection-item {
@@ -333,6 +345,41 @@ h1 {
     color: #1d4ed8;
     font-size: 13px;
     font-weight: 600;
+}
+
+.chip-dismissible {
+    gap: 8px;
+    padding-right: 6px;
+}
+
+.chip-remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: currentColor;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transition:
+        opacity 0.15s ease,
+        background 0.15s ease;
+}
+
+.chip-dismissible:hover .chip-remove,
+.chip-dismissible:focus-within .chip-remove {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.chip-remove:hover {
+    background: rgba(29, 78, 216, 0.12);
 }
 
 .metric-grid {

--- a/ui/tooltips.js
+++ b/ui/tooltips.js
@@ -1,0 +1,351 @@
+function bindHeaderInfoTooltips(container) {
+  container
+    .querySelectorAll(".table-header-trigger[data-header-kind]")
+    .forEach((cell) => {
+      cell.addEventListener("mouseenter", () => {
+        showHeaderInfoTooltip(cell);
+      });
+      cell.addEventListener("mousemove", (event) => {
+        positionHeaderInfoTooltip(event.clientX, event.clientY);
+      });
+      cell.addEventListener("mouseleave", hideHeaderInfoTooltip);
+    });
+}
+
+function showHeaderInfoTooltip(cell) {
+  const kind = cell.dataset.headerKind;
+  if (!kind) return;
+
+  const tooltipEl = getHeaderInfoTooltipElement();
+  const content = kind === "city"
+    ? buildCityHeaderTooltipContent(cell.dataset.cityId)
+    : buildCountryHeaderTooltipContent(cell.dataset.countryCode);
+
+  if (!content) {
+    tooltipEl.classList.remove("is-visible");
+    return;
+  }
+
+  tooltipEl.innerHTML = content;
+  tooltipEl.classList.add("is-visible");
+}
+
+function hideHeaderInfoTooltip() {
+  getHeaderInfoTooltipElement().classList.remove("is-visible");
+}
+
+function positionHeaderInfoTooltip(clientX, clientY) {
+  const tooltipEl = getHeaderInfoTooltipElement();
+  if (!tooltipEl.classList.contains("is-visible")) return;
+
+  const offset = 14;
+  const rect = tooltipEl.getBoundingClientRect();
+  let left = clientX + offset;
+  let top = clientY + offset;
+
+  if (left + rect.width > window.innerWidth - 12) {
+    left = clientX - rect.width - offset;
+  }
+  if (top + rect.height > window.innerHeight - 12) {
+    top = clientY - rect.height - offset;
+  }
+
+  tooltipEl.style.left = `${Math.max(12, left)}px`;
+  tooltipEl.style.top = `${Math.max(12, top)}px`;
+}
+
+function getHeaderInfoTooltipElement() {
+  let tooltipEl = document.querySelector(".header-info-tooltip");
+  if (!tooltipEl) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "header-info-tooltip";
+    document.body.appendChild(tooltipEl);
+  }
+  return tooltipEl;
+}
+
+function buildCityHeaderTooltipContent(cityID) {
+  if (!cityID) return "";
+
+  const city = state.comparisonData.find(
+    (item) => String(item.geoname_id ?? item.city_id ?? item.id ?? "") === String(cityID),
+  );
+  if (!city) return "";
+
+  const cityName = city.city ?? city.name ?? "City";
+  const population = formatCompactPopulation(city.population);
+  const utcOffset = formatUTCOffset(city.timezone);
+
+  return `
+    <div class="header-info-title">${escapeHtml(cityName)}</div>
+    <div class="header-info-row"><span class="header-info-key">Pop.</span><span class="header-info-value">${escapeHtml(population)}</span></div>
+    <div class="header-info-row"><span class="header-info-key">UTC</span><span class="header-info-value">${escapeHtml(utcOffset)}</span></div>
+  `;
+}
+
+function buildCountryHeaderTooltipContent(countryCode) {
+  if (!countryCode) return "";
+
+  const country = state.countryComparisonData.find(
+    (item) => String(item.country_code ?? "") === String(countryCode),
+  );
+  if (!country) return "";
+
+  const countryName =
+    country.country ?? country.country_name ?? country.country_code ?? "Country";
+  const population = formatCompactPopulation(country.population);
+  const area = formatCompactArea(country.area);
+
+  return `
+    <div class="header-info-title">${escapeHtml(countryName)}</div>
+    <div class="header-info-row"><span class="header-info-key">Pop.</span><span class="header-info-value">${escapeHtml(population)}</span></div>
+    <div class="header-info-row"><span class="header-info-key">Area</span><span class="header-info-value">${escapeHtml(area)}</span></div>
+  `;
+}
+
+function renderClimateTooltip(context, options) {
+  const { chart, tooltip } = context;
+  const tooltipEl = getClimateTooltipElement(chart);
+
+  if (tooltip.opacity === 0 || !tooltip.dataPoints?.length) {
+    tooltipEl.classList.remove("is-visible");
+    return;
+  }
+
+  const dataPoint = tooltip.dataPoints[0];
+  const dataset = dataPoint.dataset;
+  const cityKey = dataset.cityKey;
+  const cityLabel = dataset.cityLabel;
+  const monthLabel = dataPoint.label;
+  const color = dataset._baseColor ?? "#2563eb";
+
+  let contentHtml = "";
+  if (options.chartKey === "temperature") {
+    const highDataset = chart.data.datasets.find(
+      (item) => item.cityKey === cityKey && item.variant === "high",
+    );
+    const lowDataset = chart.data.datasets.find(
+      (item) => item.cityKey === cityKey && item.variant === "low",
+    );
+    const highValue = toNumber(highDataset?.data?.[dataPoint.dataIndex]);
+    const lowValue = toNumber(lowDataset?.data?.[dataPoint.dataIndex]);
+    const highParts = formatTooltipValueParts(highValue, "°C");
+    const lowParts = formatTooltipValueParts(lowValue, "°C");
+    const highHtml = `
+      <span class="chart-tooltip-value-number">${escapeHtml(highParts.value)}</span>${highParts.unit ? ` <span class="chart-tooltip-unit">${escapeHtml(highParts.unit)}</span>` : ""}
+    `;
+    const lowHtml = `
+      <span class="chart-tooltip-value-number">${escapeHtml(lowParts.value)}</span>${lowParts.unit ? ` <span class="chart-tooltip-unit">${escapeHtml(lowParts.unit)}</span>` : ""}
+    `;
+    contentHtml = `
+      <div class="chart-tooltip-city">${escapeHtml(cityLabel)}</div>
+      <div class="chart-tooltip-text">${escapeHtml(monthLabel)}:</div>
+      <div class="chart-tooltip-metric">
+        <span class="chart-tooltip-key">High:</span>
+        <span class="chart-tooltip-value">${highHtml}</span>
+      </div>
+      <div class="chart-tooltip-metric">
+        <span class="chart-tooltip-key">Low:</span>
+        <span class="chart-tooltip-value">${lowHtml}</span>
+      </div>
+    `;
+  } else {
+    const value = toNumber(dataPoint.parsed?.y);
+    const valueParts = formatTooltipValueParts(value, options.yTitle);
+    const valueHtml = valueParts.unit
+      ? `${escapeHtml(valueParts.value)} <span class="chart-tooltip-unit">${escapeHtml(valueParts.unit)}</span>`
+      : escapeHtml(valueParts.value);
+    contentHtml = `
+      <div class="chart-tooltip-city">${escapeHtml(cityLabel)}</div>
+      <div class="chart-tooltip-metric chart-tooltip-metric-inline">
+        <span class="chart-tooltip-key">${escapeHtml(monthLabel)}</span>
+        <span class="chart-tooltip-value">${valueHtml}</span>
+      </div>
+    `;
+  }
+
+  tooltipEl.innerHTML = `
+    <div class="chart-tooltip-row">
+      <span class="chart-tooltip-swatch" style="background:${escapeHtml(color)}"></span>
+      <div>${contentHtml}</div>
+    </div>
+  `;
+
+  const { offsetLeft: positionX, offsetTop: positionY } = chart.canvas;
+  tooltipEl.style.left = `${positionX + tooltip.caretX + 14}px`;
+  tooltipEl.style.top = `${positionY + tooltip.caretY - 12}px`;
+  tooltipEl.classList.add("is-visible");
+}
+
+function getClimateTooltipElement(chart) {
+  const parent = chart.canvas.parentNode;
+  let tooltipEl = parent.querySelector(".chart-tooltip");
+
+  if (!tooltipEl) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "chart-tooltip";
+    parent.appendChild(tooltipEl);
+  }
+
+  return tooltipEl;
+}
+
+function bindLegatumTooltipEvents() {
+  els.legatumIndicesBody
+    .querySelectorAll("[data-legatum-row-key][data-legatum-country-code]")
+    .forEach((cell) => {
+      cell.addEventListener("mouseenter", () => {
+        showLegatumTooltip(cell);
+      });
+      cell.addEventListener("mousemove", (event) => {
+        positionLegatumTooltip(event.clientX, event.clientY);
+      });
+      cell.addEventListener("mouseleave", hideLegatumTooltip);
+    });
+}
+
+function showLegatumTooltip(cell) {
+  const rowKey = cell.dataset.legatumRowKey;
+  const countryCode = cell.dataset.legatumCountryCode;
+  if (!rowKey || !countryCode) return;
+
+  const country = state.countryComparisonData.find(
+    (item) => item.country_code === countryCode,
+  );
+  const row = legatumIndexRows.find((item) => item.key === rowKey);
+  if (!country || !row) return;
+
+  const tooltipEl = getLegatumTooltipElement();
+  const isRankMode = state.legatumMetricMode === "rank";
+  const series = buildLegatumSeries(
+    country.legatum_indices?.[rowKey],
+    isRankMode ? "rank" : "score",
+  );
+  if (!series.length) {
+    tooltipEl.classList.remove("is-visible");
+    return;
+  }
+
+  const values = series.map((point) => point.value);
+  const minValue = Math.min(...values);
+  const maxValue = Math.max(...values);
+  const currentPoint = series[series.length - 1];
+  const displayCountry = getDisplayCountryName(
+    country.country ?? country.country_name ?? country.country_code ?? countryCode,
+  );
+
+  tooltipEl.innerHTML = `
+    <div class="legatum-tooltip-title">${escapeHtml(displayCountry)}</div>
+    <div class="legatum-tooltip-subtitle">${escapeHtml(row.label)} • ${escapeHtml(isRankMode ? "Rank" : "Score")}</div>
+    <div class="legatum-tooltip-current">${escapeHtml(String(currentPoint.year))}: ${escapeHtml(String(currentPoint.value))}</div>
+    <div class="legatum-tooltip-chart">
+      ${renderLegatumSparkline(series, { minValue, maxValue, isRankMode })}
+    </div>
+  `;
+  tooltipEl.classList.add("is-visible");
+}
+
+function hideLegatumTooltip() {
+  getLegatumTooltipElement().classList.remove("is-visible");
+}
+
+function positionLegatumTooltip(clientX, clientY) {
+  const tooltipEl = getLegatumTooltipElement();
+  if (!tooltipEl.classList.contains("is-visible")) return;
+
+  const offset = 16;
+  const { innerWidth, innerHeight } = window;
+  const rect = tooltipEl.getBoundingClientRect();
+  let left = clientX + offset;
+  let top = clientY + offset;
+
+  if (left + rect.width > innerWidth - 12) {
+    left = clientX - rect.width - offset;
+  }
+  if (top + rect.height > innerHeight - 12) {
+    top = clientY - rect.height - offset;
+  }
+
+  tooltipEl.style.left = `${Math.max(12, left)}px`;
+  tooltipEl.style.top = `${Math.max(12, top)}px`;
+}
+
+function getLegatumTooltipElement() {
+  let tooltipEl = document.querySelector(".legatum-tooltip");
+  if (!tooltipEl) {
+    tooltipEl = document.createElement("div");
+    tooltipEl.className = "legatum-tooltip";
+    document.body.appendChild(tooltipEl);
+  }
+  return tooltipEl;
+}
+
+function buildLegatumSeries(entry, mode) {
+  if (!entry) return [];
+
+  return legatumYears
+    .map((year) => ({
+      year,
+      value: toNumber(entry[`${mode}_${year}`]),
+    }))
+    .filter((point) => point.value != null);
+}
+
+function renderLegatumSparkline(series, { minValue, maxValue, isRankMode }) {
+  const width = 230;
+  const height = 122;
+  const padding = { top: 10, right: 30, bottom: 24, left: 8 };
+  const plotWidth = width - padding.left - padding.right;
+  const plotHeight = height - padding.top - padding.bottom;
+  const range = maxValue - minValue || 1;
+  const midYear = 2015;
+  const midX =
+    padding.left +
+    (plotWidth * (midYear - legatumYears[0])) /
+      Math.max(1, legatumYears.length - 1);
+  const midValue = (minValue + maxValue) / 2;
+  const midNormalized = isRankMode
+    ? (maxValue - midValue) / range
+    : (midValue - minValue) / range;
+  const midY = padding.top + plotHeight - midNormalized * plotHeight;
+
+  const points = series.map((point, index) => {
+    const x =
+      padding.left +
+      (plotWidth * index) / Math.max(1, series.length - 1);
+    const normalized = isRankMode
+      ? (maxValue - point.value) / range
+      : (point.value - minValue) / range;
+    const y = padding.top + plotHeight - normalized * plotHeight;
+    return { ...point, x, y };
+  });
+
+  const polylinePoints = points.map((point) => `${point.x},${point.y}`).join(" ");
+  const stroke = isRankMode ? "#2563eb" : "#0f766e";
+  const topAxisValue = isRankMode ? minValue : maxValue;
+  const bottomAxisValue = isRankMode ? maxValue : minValue;
+
+  return `
+    <svg viewBox="0 0 ${width} ${height}" class="legatum-tooltip-sparkline" aria-hidden="true">
+      <line x1="${padding.left}" y1="${padding.top}" x2="${width - padding.right}" y2="${padding.top}" class="legatum-tooltip-grid" />
+      <line x1="${padding.left}" y1="${midY}" x2="${width - padding.right}" y2="${midY}" class="legatum-tooltip-grid legatum-tooltip-grid-mid" />
+      <line x1="${padding.left}" y1="${padding.top + plotHeight}" x2="${width - padding.right}" y2="${padding.top + plotHeight}" class="legatum-tooltip-grid" />
+      <line x1="${midX}" y1="${padding.top + plotHeight}" x2="${midX}" y2="${padding.top + plotHeight + 5}" class="legatum-tooltip-axis-tick legatum-tooltip-axis-tick-mid" />
+      <polyline points="${polylinePoints}" fill="none" stroke="${stroke}" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" />
+      <circle cx="${points[0].x}" cy="${points[0].y}" r="2.5" fill="${stroke}" />
+      <circle cx="${points[points.length - 1].x}" cy="${points[points.length - 1].y}" r="3" fill="${stroke}" />
+      <text x="${width - 2}" y="${padding.top + 4}" text-anchor="end" class="legatum-tooltip-y-label">${escapeHtml(String(topAxisValue))}</text>
+      <text x="${width - 2}" y="${midY + 3}" text-anchor="end" class="legatum-tooltip-y-label legatum-tooltip-y-label-mid">${escapeHtml(formatLegatumAxisMidValue(midValue))}</text>
+      <text x="${width - 2}" y="${padding.top + plotHeight}" text-anchor="end" dominant-baseline="ideographic" class="legatum-tooltip-y-label">${escapeHtml(String(bottomAxisValue))}</text>
+      <text x="${padding.left}" y="${height - 4}" text-anchor="start" class="legatum-tooltip-x-label">2007</text>
+      <text x="${midX}" y="${height - 4}" text-anchor="middle" class="legatum-tooltip-x-label legatum-tooltip-x-label-mid">2015</text>
+      <text x="${width - padding.right}" y="${height - 4}" text-anchor="end" class="legatum-tooltip-x-label">2023</text>
+    </svg>
+  `;
+}
+
+Object.assign(window, {
+  bindHeaderInfoTooltips,
+  renderClimateTooltip,
+  bindLegatumTooltipEvents,
+});


### PR DESCRIPTION
## Summary

This PR adds the first dashboard UI for Relohelper.

The project remains API-first, but now includes a reference UI built on top of the existing API for comparing cities by cost of living, climate, and quality of life.

## Included

- dashboard page at `/`
- improved country/city filter workflow
- `Cost of Living` table with collapsible categories, sticky layout, sorting, and heatmap highlighting
- `Climate` charts for temperature, sunshine, daylight, humidity, rainfall, wind, and UV index
- `Numbeo Indices by City`
- `Numbeo Indices by Country`
- `The Legatum Prosperity Index` with score/rank toggle and historical sparkline tooltips
- hover tooltips for table headers
- favicon support for dashboard and Swagger UI

## Notes

- compare actions use existing batch API endpoints
- most dashboard interactions are handled client-side after data is loaded
- frontend code was reorganized into shared modules for helpers, tooltips, and climate logic
