### PR TITLE
Improve dashboard translation behavior and README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Performance comparison between Go and Python implementations is documented [here
 
 ## Public Access
 
-- Dashboard UI: `https://relohelper.pro/`
-- Swagger UI: `https://relohelper.pro/swagger`
+- Dashboard UI: [https://relohelper.pro/](https://relohelper.pro/)
+- Swagger UI: [https://relohelper.pro/swagger](https://relohelper.pro/swagger)
 - `/metrics` is internal-only
 - Grafana is available through SSH tunneling only
 

--- a/ui/app.js
+++ b/ui/app.js
@@ -363,7 +363,7 @@ function renderCountries() {
           <input type="checkbox" data-country-code="${escapeHtml(code)}" ${checked} />
           <div class="selection-item-main">
             <span class="selection-title">${escapeHtml(name)}</span>
-            <span class="selection-subtitle">${escapeHtml(code)}</span>
+            <span class="selection-subtitle notranslate" translate="no">${escapeHtml(code)}</span>
           </div>
         </label>
       `;
@@ -636,7 +636,7 @@ function renderCostBreakdownTable() {
                 isSalaryRow ? "high" : "low",
               );
 
-              return `<td class="${cellClass}">${escapeHtml(formatCostValue(value, { isMortgageRate: isMortgageRateRow }))}</td>`;
+              return `<td class="${cellClass} notranslate" translate="no">${escapeHtml(formatCostValue(value, { isMortgageRate: isMortgageRateRow }))}</td>`;
             })
             .join("");
 
@@ -855,7 +855,12 @@ function renderNumbeoIndicesTableSection({
             isHigherBetter ? "high" : "low",
           );
 
-          return `<td class="${cellClass}" ${cellDataAttrs}>${escapeHtml(formatIndexValue(value, row))}</td>`;
+          const translateAttrs =
+            row.format === "currency"
+              ? ' class="' + cellClass + ' notranslate" translate="no"'
+              : ` class="${cellClass}"`;
+
+          return `<td${translateAttrs} ${cellDataAttrs}>${escapeHtml(formatIndexValue(value, row))}</td>`;
         })
         .join("");
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -16,7 +16,7 @@
         <div class="app-shell">
             <header class="topbar">
                 <div class="page-header">
-                    <h1>Relohelper</h1>
+                    <h1 class="notranslate" translate="no">Relohelper</h1>
                     <p class="subtitle">
                         Compare cities by cost, climate, and quality of life.
                     </p>
@@ -281,14 +281,16 @@
                         <div class="table-mode-toggle" role="group" aria-label="Legatum metric mode">
                             <button
                                 id="legatumScoreToggle"
-                                class="table-mode-toggle-btn is-active"
+                                class="table-mode-toggle-btn is-active notranslate"
+                                translate="no"
                                 type="button"
                             >
                                 Score
                             </button>
                             <button
                                 id="legatumRankToggle"
-                                class="table-mode-toggle-btn"
+                                class="table-mode-toggle-btn notranslate"
+                                translate="no"
                                 type="button"
                             >
                                 Rank

--- a/ui/tooltips.js
+++ b/ui/tooltips.js
@@ -58,7 +58,8 @@ function getHeaderInfoTooltipElement() {
   let tooltipEl = document.querySelector(".header-info-tooltip");
   if (!tooltipEl) {
     tooltipEl = document.createElement("div");
-    tooltipEl.className = "header-info-tooltip";
+    tooltipEl.className = "header-info-tooltip notranslate";
+    tooltipEl.setAttribute("translate", "no");
     document.body.appendChild(tooltipEl);
   }
   return tooltipEl;
@@ -183,7 +184,8 @@ function getClimateTooltipElement(chart) {
 
   if (!tooltipEl) {
     tooltipEl = document.createElement("div");
-    tooltipEl.className = "chart-tooltip";
+    tooltipEl.className = "chart-tooltip notranslate";
+    tooltipEl.setAttribute("translate", "no");
     parent.appendChild(tooltipEl);
   }
 
@@ -274,7 +276,8 @@ function getLegatumTooltipElement() {
   let tooltipEl = document.querySelector(".legatum-tooltip");
   if (!tooltipEl) {
     tooltipEl = document.createElement("div");
-    tooltipEl.className = "legatum-tooltip";
+    tooltipEl.className = "legatum-tooltip notranslate";
+    tooltipEl.setAttribute("translate", "no");
     document.body.appendChild(tooltipEl);
   }
   return tooltipEl;


### PR DESCRIPTION
## Summary

This PR improves dashboard resilience under browser auto-translation and updates public links in the README.

## Included

- prevent browser translation from breaking dashboard values, tooltips, labels, and controls
- keep product and control labels like `Relohelper`, `Score`, `Rank`, and country codes stable under auto-translate
- add clickable public dashboard and Swagger links to the README

## Notes

- no API changes
- no major dashboard feature changes
- focused on UI stability and documentation cleanup
