### PR TITLE
Make dashboard brand header clickable

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -16,9 +16,16 @@
         <div class="app-shell">
             <header class="topbar">
                 <div class="page-header">
-                    <h1 class="brand brand-b notranslate" translate="no">
-                        <span class="brand-accent">Relo</span>helper
-                    </h1>
+                    <a
+                        href="/"
+                        class="brand brand-link notranslate"
+                        translate="no"
+                        aria-label="Relohelper home"
+                    >
+                        <h1 class="brand-b">
+                            <span class="brand-accent">Relo</span>helper
+                        </h1>
+                    </a>
                     <p class="subtitle">
                         Compare cities by cost, climate, and quality of life.
                     </p>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -136,6 +136,11 @@ h1 {
     color: #0f172a;
 }
 
+.brand-link {
+    display: inline-block;
+    text-decoration: none;
+}
+
 .brand-accent {
     color: #3b82f6;
 }


### PR DESCRIPTION
## Summary

This PR makes the main dashboard brand header clickable.

## Included

- turn the `Relohelper` brand header into a link to `/`
- preserve the current visual styling of the header
- keep the existing subtitle and accent hover behavior

## Notes

- no API changes
- no layout changes outside the header
