### PR TITLE
Restore brand header spacing after clickable link change

### DIFF
--- a/ui/styles.css
+++ b/ui/styles.css
@@ -137,7 +137,8 @@ h1 {
 }
 
 .brand-link {
-    display: inline-block;
+    display: block;
+    width: fit-content;
     text-decoration: none;
 }
 


### PR DESCRIPTION
## Summary

This PR restores the original spacing between the main dashboard brand header and the subtitle after the header was turned into a clickable link.

## Included

- adjust the clickable brand wrapper layout
- remove the extra gap introduced by the link wrapper
- preserve the current brand styling and click behavior

## Notes

- no API changes
- no feature changes
- spacing/layout fix only
